### PR TITLE
Converge repo protection config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: "Default CodeQL config"
+
+# Run the security-extended suite (the default security queries plus
+# additional lower-severity security queries). Switch to
+# "security-and-quality" if the repo wants the broader (noisier)
+# maintainability/quality queries too.
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  - "**/node_modules/**"
+  - "**/vendor/**"
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/*.min.js"
+  - "**/generated/**"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/scripts/no-back-merging-guard.sh
+++ b/.github/scripts/no-back-merging-guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# no-back-merging-guard.sh
+#
+# Reject PR head branches that contain a back-merge from the base branch.
+# A "back-merge" is a merge commit on the head branch whose second parent
+# (the "incoming" side of the merge) is reachable from the base branch
+# tip. That is the signature of `git merge origin/<base>` performed on
+# the feature branch. Feature branches must rebase, not merge, to bring
+# in upstream changes.
+#
+# Walk only commits unique to the head branch (`<base>..<head>`). Merge
+# commits whose ancestors happen to be on `<base>` from a previous
+# round-trip are NOT in that range, so they cannot trigger a false
+# positive. Internal merges from a sub-branch (where the second parent
+# is NOT reachable from `<base>`) are accepted.
+#
+# Inputs:
+#   $1 -- base ref (e.g. "origin/main")
+#   $2 -- head ref or SHA (defaults to HEAD)
+#
+# Exit codes:
+#   0 -- clean: no back-merges detected
+#   1 -- back-merge detected
+#   2 -- usage / git error
+#
+# Used by .github/workflows/no-back-merging-guard.yml. Self-tested by
+# .github/scripts/test-no-back-merging-guard.sh.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "usage: $0 <base-ref> [head-ref]" >&2
+  exit 2
+fi
+
+BASE="$1"
+HEAD="${2:-HEAD}"
+
+if ! git rev-parse --verify --quiet "$BASE" >/dev/null; then
+  echo "::error::base ref '$BASE' not found. Fetch it before running this guard." >&2
+  exit 2
+fi
+
+if ! git rev-parse --verify --quiet "$HEAD" >/dev/null; then
+  echo "::error::head ref '$HEAD' not found." >&2
+  exit 2
+fi
+
+# Walk only merge commits unique to the head branch.
+found=0
+while read -r merge_sha; do
+  [ -z "$merge_sha" ] && continue
+
+  # Parents of the merge: parent1 is the trunk side of the feature
+  # branch at the time of the merge; parent2 is the "incoming" side.
+  # A back-merge from <base> shows up as parent2 being reachable from
+  # the current <base> tip.
+  parents=$(git log -1 --pretty=%P "$merge_sha")
+  # shellcheck disable=SC2206  # word-splitting is intentional
+  parent_arr=($parents)
+
+  if [ "${#parent_arr[@]}" -lt 2 ]; then
+    # Defensive: --merges should only return commits with >=2 parents.
+    continue
+  fi
+
+  second_parent="${parent_arr[1]}"
+  if git merge-base --is-ancestor "$second_parent" "$BASE" 2>/dev/null; then
+    echo "::error::Back-merge detected in $merge_sha -- its incoming parent $second_parent is reachable from $BASE."
+    echo "Rebase your branch onto $BASE instead: git fetch origin && git rebase $BASE"
+    found=1
+  fi
+done < <(git log --merges "$BASE..$HEAD" --pretty=%H)
+
+if [ "$found" -eq 1 ]; then
+  exit 1
+fi
+
+echo "OK: no back-merges from $BASE on $HEAD."
+exit 0

--- a/.github/scripts/test-no-back-merging-guard.sh
+++ b/.github/scripts/test-no-back-merging-guard.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# test-no-back-merging-guard.sh
+#
+# Self-test for .github/scripts/no-back-merging-guard.sh. Builds throwaway git
+# repos under a temp dir and verifies that the guard accepts clean
+# branches and rejects branches that contain `git merge <base>`.
+#
+# Cases:
+#   (a) Clean linear feature branch -- pass
+#   (b) Feature branch with `git merge <base>` -- fail
+#   (c) Feature branch with an internal merge from a sub-branch (no
+#       main-ancestor parent) -- pass (no false positive)
+#   (d) Feature branch that back-merged base earlier, base then
+#       advances further -- still fail (the merge is still in
+#       <base>..HEAD and parent2 is still reachable from <base>)
+#
+# Exit codes:
+#   0 -- all cases pass
+#   1 -- any case fails
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/no-back-merging-guard.sh"
+
+if [ ! -x "$GUARD" ]; then
+  echo "FAIL: guard script not executable at $GUARD" >&2
+  exit 1
+fi
+
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t no-back-merging-guard)
+trap 'rm -rf "$TMP"' EXIT
+
+pass=0
+fail=0
+
+# Common author identity so commits work without global git config.
+git_init_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email "test@example.com"
+  git -C "$dir" config user.name "Test User"
+  git -C "$dir" config commit.gpgsign false
+}
+
+commit_file() {
+  local dir="$1" file="$2" msg="$3"
+  echo "$msg" > "$dir/$file"
+  git -C "$dir" add "$file"
+  git -C "$dir" commit -q -m "$msg"
+}
+
+run_case() {
+  local name="$1" expected_exit="$2" repo="$3" base="$4" head="$5"
+  local out actual
+  set +e
+  out=$(cd "$repo" && "$GUARD" "$base" "$head" 2>&1)
+  actual=$?
+  set -e
+  if [ "$actual" = "$expected_exit" ]; then
+    pass=$((pass + 1))
+    echo "PASS [$name] (exit $actual)"
+  else
+    fail=$((fail + 1))
+    echo "FAIL [$name] expected exit $expected_exit, got $actual"
+    echo "----- guard output -----"
+    echo "$out"
+    echo "------------------------"
+  fi
+}
+
+# ---------------------------------------------------------------
+# Case (a): Clean linear feature branch
+# ---------------------------------------------------------------
+REPO_A="$TMP/case-a"
+git_init_repo "$REPO_A"
+commit_file "$REPO_A" base.txt "base 1"
+commit_file "$REPO_A" base.txt "base 2"
+git -C "$REPO_A" checkout -q -b feature
+commit_file "$REPO_A" feat.txt "feat 1"
+commit_file "$REPO_A" feat.txt "feat 2"
+run_case "a: clean linear feature" 0 "$REPO_A" main feature
+
+# ---------------------------------------------------------------
+# Case (b): Feature branch with `git merge main`
+# ---------------------------------------------------------------
+REPO_B="$TMP/case-b"
+git_init_repo "$REPO_B"
+commit_file "$REPO_B" base.txt "base 1"
+git -C "$REPO_B" checkout -q -b feature
+commit_file "$REPO_B" feat.txt "feat 1"
+git -C "$REPO_B" checkout -q main
+commit_file "$REPO_B" base.txt "base 2"
+git -C "$REPO_B" checkout -q feature
+# This is the forbidden operation: pull main into the feature branch
+# via a merge commit instead of rebasing.
+git -C "$REPO_B" merge -q --no-ff -m "Merge branch 'main' into feature" main
+commit_file "$REPO_B" feat.txt "feat 2 after back-merge"
+run_case "b: back-merge from main" 1 "$REPO_B" main feature
+
+# ---------------------------------------------------------------
+# Case (c): Internal merge from a sub-branch (no main-ancestor parent)
+# ---------------------------------------------------------------
+REPO_C="$TMP/case-c"
+git_init_repo "$REPO_C"
+commit_file "$REPO_C" base.txt "base 1"
+git -C "$REPO_C" checkout -q -b feature
+commit_file "$REPO_C" feat.txt "feat 1"
+git -C "$REPO_C" checkout -q -b sub-feature
+commit_file "$REPO_C" sub.txt "sub 1"
+commit_file "$REPO_C" sub.txt "sub 2"
+git -C "$REPO_C" checkout -q feature
+# Merging a sub-branch INTO the feature branch is fine: the second
+# parent (sub-feature tip) is NOT reachable from main.
+git -C "$REPO_C" merge -q --no-ff -m "Merge sub-feature into feature" sub-feature
+run_case "c: internal merge from sub-branch" 0 "$REPO_C" main feature
+
+# ---------------------------------------------------------------
+# Case (d): Back-merge then main advances further -- still fail
+# ---------------------------------------------------------------
+REPO_D="$TMP/case-d"
+git_init_repo "$REPO_D"
+commit_file "$REPO_D" base.txt "base 1"
+git -C "$REPO_D" checkout -q -b feature
+commit_file "$REPO_D" feat.txt "feat 1"
+git -C "$REPO_D" checkout -q main
+commit_file "$REPO_D" base.txt "base 2"
+git -C "$REPO_D" checkout -q feature
+git -C "$REPO_D" merge -q --no-ff -m "Merge branch 'main' into feature (early)" main
+commit_file "$REPO_D" feat.txt "feat 2"
+# Main advances further AFTER the back-merge. The back-merge commit
+# stays in main..feature and its second parent stays reachable from
+# main, so the guard must still reject.
+git -C "$REPO_D" checkout -q main
+commit_file "$REPO_D" base.txt "base 3"
+run_case "d: back-merge then main advances" 1 "$REPO_D" main feature
+
+# ---------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan to catch advisories published after the last push.
+    - cron: "27 3 * * 1"
+
+# Only the latest run per ref needs to complete; cancel superseded runs.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least-privilege default for the GITHUB_TOKEN. The analyze job sets its
+# own permissions block, which REPLACES (does not merge with) this one,
+# so every permission the job needs must be listed at the job level.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # A job-level permissions block replaces the top-level one
+      # entirely, so every permission the job needs is listed here.
+      security-events: write # upload analysis results to the Security tab
+      packages: read # fetch CodeQL query packs
+      actions: read # required for code scanning on a private repo
+      contents: read # clone the repository
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'actions' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          # Path filters and query packs live in the sibling config file.
+          config-file: ./.github/codeql/codeql-config.yml
+
+      # No manual build step: the analyzed languages are extracted from
+      # source without a compile, so CodeQL's default extraction covers
+      # them without autobuild (which only adds a failure surface).
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/no-back-merging-guard.yml
+++ b/.github/workflows/no-back-merging-guard.yml
@@ -1,0 +1,35 @@
+name: no-back-merging-guard
+on:
+  pull_request:
+    branches: [main]
+
+# This is the only required status check on `main`. It
+# rejects PRs whose head branch contains a back-merge from
+# `main` (a merge commit whose incoming parent is
+# reachable from `origin/main`). Feature branches must
+# rebase onto the default branch, not merge it in.
+#
+# Logic lives in .github/scripts/no-back-merging-guard.sh. Self-tested
+# by .github/scripts/test-no-back-merging-guard.sh. The guard avoids the
+# false-positive of the previous block-back-merges-from-base workflow,
+# which checked all parents of every merge commit and flagged merges
+# that became "tainted" by prior round-trips.
+
+jobs:
+  no-back-merging-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        env:
+          BASE: ${{ github.base_ref }}
+        run: git fetch origin "$BASE"
+
+      - name: Run no-back-merging guard
+        env:
+          BASE: ${{ github.base_ref }}
+        run: bash .github/scripts/no-back-merging-guard.sh "origin/$BASE" HEAD

--- a/.github/workflows/no-back-merging-guard.yml
+++ b/.github/workflows/no-back-merging-guard.yml
@@ -3,6 +3,13 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for the GITHUB_TOKEN. The guard only checks
+# out the repo and runs a shell script, so read access to contents is
+# all it needs; this root-level block applies to every job unless a job
+# overrides it.
+permissions:
+  contents: read
+
 # This is the only required status check on `main`. It
 # rejects PRs whose head branch contains a back-merge from
 # `main` (a merge commit whose incoming parent is


### PR DESCRIPTION
Rendered by /gh-repo-setup-protection: hardened Dependabot config (github-actions ecosystem), an Advanced CodeQL workflow (language: actions) with its security-extended config, and the unconditional no-back-merging-guard workflow plus its script and self-test.

The dependency-install-gate was skipped (no npm/pip/pnpm/yarn manifest in this shell/Makefile/Lua repo).

Remote settings — GHAS toggles, merge-button settings, the `protect-main` ruleset, and disabling the server-side CodeQL default setup so the advanced workflow can take over — were applied directly to the repo and are not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuGetcR3b2kogErf134rRR