### PR TITLE
Add public-repo community files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @evoskamp
-/computer-specific/irenes-macmini/ @irene-voskamp
-/computer-specific/polaris/ @EllenOrange

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,12 @@
+# Contributors
+
+This is a public repository and contributions are welcome — see the
+"Contributing" section of README.md for how to fork, open a pull
+request, and file issues.
+
+This file deliberately does not embed a frozen contributor list: that
+data is reproducible from the repository's own history and would go
+stale on every commit. To list contributors from the current history,
+run:
+
+    git shortlog -sne

--- a/README.md
+++ b/README.md
@@ -1218,3 +1218,19 @@ alternative setup methods including:
 
 This repository is for personal use. Feel free to fork
 and adapt for your own needs.
+
+## Contributing
+
+This is a public repository. Contributions are welcome:
+
+- **Fork** the repository and create a feature branch from the default
+  branch.
+- **Open a pull request** from your fork. PRs require a passing CI run,
+  code-owner review (`@evoskamp`), and all review conversations
+  resolved before they can merge.
+- **File an issue** to report a bug or propose a change. Any logged-in
+  GitHub user can open and comment on issues.
+
+Outside contributors have read access: you can fork, open PRs from your
+fork, and file/comment on issues. Push access, merging, and issue
+triage are reserved for maintainers.


### PR DESCRIPTION
## Summary

The repo is now public. This adds the community-facing files that go with that posture (split out of in-progress working-tree changes so they land as their own focused PR rather than mixing with unrelated work).

- **CODEOWNERS**: drop the two `computer-specific/` path owners; a public repo's ownership collapses to the single maintainer (`@evoskamp`).
- **README**: add a "Contributing" section describing the fork → PR flow, the merge gates (CI, code-owner review, resolved conversations), and the read-only access outside contributors have.
- **CONTRIBUTORS**: a pointer file that defers to README's Contributing section and `git shortlog -sne` rather than freezing a list that would go stale on every commit.

## Test plan

- [ ] Docs-only / config-only change; no behavior to exercise.
- [ ] Confirm CODEOWNERS still parses (single `* @evoskamp` rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)