### PR TITLE
Simplify bootstrap.sh to HTTPS clone for the public repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ centrally in `scripts/config_common.sh`):
 ### Initial Setup
 
 ```bash
-./bootstrap.sh        # Install Homebrew, 1Password, dasel, clone repo
+./bootstrap.sh        # Install Homebrew, mas, dasel; HTTPS-clone the (public) repo
 make install          # Apply all Install/ files in order
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,19 @@ bash ./bootstrap.sh
    **dasel** (the TOML query primitive `config.toml` relies
    on), then verifies the installed dasel is **exactly major
    version 3** — a non-v3 dasel fails this step loudly
-2. Installs **1Password** and guides you through SSH
-   agent setup
-3. Installs **Apple Command Line Tools** (git)
-4. Tests **GitHub SSH authentication**
-5. Clones this repository to `./macos-setup`
-6. Provides next steps
+2. Installs **Apple Command Line Tools** (git)
+3. Clones this (public) repository to `./macos-setup` over
+   **HTTPS** — no SSH key or 1Password SSH agent required
+4. Provides next steps
+
+> This repo is public, so the bootstrap clone needs no
+> credentials. 1Password is no longer installed by the
+> bootstrap itself (it still comes in via `make security`),
+> and the 1Password SSH-agent setup the bootstrap used to walk
+> you through now lives in
+> [docs/1password-as-ssh-agent.md](docs/1password-as-ssh-agent.md)
+> for when you *do* need SSH auth (pushing to this repo,
+> cloning private repos).
 
 ### Step 2: Install Everything
 
@@ -1146,12 +1153,14 @@ alternative setup methods including:
 - **macOS** (tested on macOS 14+)
 - **Internet connection** for downloads
 - **Apple ID** signed into Mac App Store (for MAS apps)
-- **1Password** (installed automatically by bootstrap)
 - **dasel v3** — the `config.toml` query primitive; installed
   and version-verified automatically by bootstrap. Must be
   exactly major version 3 (v2 and v4+ are rejected); a non-v3
   dasel hard-aborts `make`/config reads loudly
-- **GitHub account** with SSH access
+- **1Password** — not required to bootstrap (the repo is public
+  and clones over HTTPS), but installed by `make security`. Set
+  it up as your SSH agent when you need SSH auth — see
+  [docs/1password-as-ssh-agent.md](docs/1password-as-ssh-agent.md)
 
 ## Documentation
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
-# bootstrap-ssh.sh
-# Combined minimal bootstrap for macOS over SSH.
+# bootstrap.sh
+# Combined minimal bootstrap for macOS.
 # Order:
 #   1) Install Homebrew
-#   2) Install 1Password via Homebrew (cask)
-#   3) Install mas (via Homebrew)
-#   4) Install dasel (via Homebrew) — the TOML query primitive config.toml relies on
-#   5) Add zsh aliases for brew/mas (before any checks that might use them)
-#   6) Ensure Apple Command Line Tools (after you've cloned this repo)
-#   7) Check MAS login (non-fatal if not signed in)
+#   2) Install mas (via Homebrew)
+#   3) Install dasel (via Homebrew) — the TOML query primitive config.toml relies on
+#   4) Add zsh aliases for brew/mas (before any checks that might use them)
+#   5) Ensure Apple Command Line Tools (git)
+#   6) Check MAS login (non-fatal if not signed in)
+#   7) Clone this (public) repository over HTTPS
 #
 # Notes:
 # - Idempotent: Safe to re-run.
 # - Aliases are written to ~/.zprofile and ~/.zshrc (and $ZDOTDIR equivalents) only if missing.
 # - MAS login check will open App Store if GUI is available; over pure SSH it will just warn.
+# - This repo is public, so the clone is a plain HTTPS clone — no SSH key,
+#   no 1Password SSH agent, no GitHub SSH auth needed. The 1Password
+#   SSH-agent setup that this script used to walk you through is preserved
+#   as reference in docs/1password-as-ssh-agent.md (still useful when you
+#   DO need SSH auth — e.g. pushing to this repo or cloning private repos).
 
 set -euo pipefail
 
@@ -89,17 +94,13 @@ install_homebrew() {
   brew update
 }
 
-install_1password_via_brew() {
-  brew install --cask 1password || brew upgrade --cask 1password || true
-}
-
 install_mas() {
   brew install mas || brew upgrade mas || true
 }
 
 # dasel is the TOML query primitive every config.toml consumer relies on
 # (scripts/config_common.sh and the mailer/cron/claude readers). It is
-# installed here, alongside Homebrew/1Password/mas/git, so consumers can
+# installed here, alongside Homebrew/mas/git, so consumers can
 # read config.toml unconditionally with no graceful-degradation branch.
 #
 # The read layer in scripts/config_common.sh targets the dasel v3 query
@@ -219,59 +220,9 @@ check_mas_login() {
   fi
 }
 
-check_1password_ssh_setup() {
-  warn "MANUAL STEP REQUIRED: Enable and configure the 1Password SSH Agent"
-  warn ""
-  warn "1. Open 1Password → Settings → Developer"
-  warn "2. Enable 'Use the SSH agent'"
-  warn "3. Add your SSH key to 1Password's Private vault (if it isn't already)."
-  warn "   1Password can add the matching public key to your GitHub account."
-  warn ""
-  warn "4. Create the agent config file so the agent offers keys from your"
-  warn "   Private vault. Run these two commands to create it with the"
-  warn "   recommended default:"
-  warn ""
-  warn "     mkdir -p ~/.config/1Password/ssh"
-  warn "     printf '[[ssh-keys]]\\nvault = \"Private\"\\n' > ~/.config/1Password/ssh/agent.toml"
-  warn ""
-  warn "5. Point ssh at the 1Password agent socket. Make sure ~/.ssh/config"
-  warn "   contains (create the file if it does not exist):"
-  warn ""
-  warn "     Host *"
-  warn "         IdentityAgent \"~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock\""
-  warn ""
-  warn "   Then verify the agent can see your key(s):"
-  warn ""
-  warn "     SSH_AUTH_SOCK=~/Library/Group\\ Containers/2BUA8C4S2C.com.1password/t/agent.sock ssh-add -l"
-  warn ""
-  warn "   (Have multiple GitHub accounts? After the repo is cloned, see"
-  warn "    docs/CONFIGURING_1PASSWORD_SSH_AGENT_FOR_MULTIPLE_GITHUB_ACCOUNTS_ON_MACOS.md)"
-  warn ""
-  warn "Press Enter when you've completed the 1Password SSH setup..."
-  read -r
-}
-
-test_github_ssh() {
-  log "Testing GitHub SSH authentication..."
-  local ssh_output
-  ssh_output=$(ssh -T git@github.com -o ConnectTimeout=10 -o StrictHostKeyChecking=no 2>&1 || true)
-  if echo "$ssh_output" | grep -q "successfully authenticated"; then
-    log "GitHub SSH authentication successful!"
-    return 0
-  else
-    err "GitHub SSH authentication failed."
-    warn "Please ensure:"
-    warn "1. 1Password SSH agent is enabled (Settings → Developer)"
-    warn "2. Your SSH key is added to 1Password's Private vault"
-    warn "3. ~/.config/1Password/ssh/agent.toml exists and references your vault"
-    warn "4. ~/.ssh/config points IdentityAgent at the 1Password agent socket"
-    warn "5. Your SSH key is added to your GitHub account"
-    return 1
-  fi
-}
-
 clone_repository() {
-  local repo_url="git@github.com:TheVoskamps/macos-setup.git"
+  # This repo is public, so a plain HTTPS clone needs no credentials.
+  local repo_url="https://github.com/TheVoskamps/macos-setup.git"
   local target_dir="./macos-setup"
 
   if [[ -d "$target_dir" ]]; then
@@ -287,22 +238,19 @@ clone_repository() {
     log "  make install"
     return 0
   else
-    err "Failed to clone repository. Please check your SSH setup and try again."
+    err "Failed to clone repository over HTTPS. Check your network connection and try again."
     return 1
   fi
 }
 
 main() {
   step "Install Homebrew" install_homebrew
-  step "Install 1Password (cask)" install_1password_via_brew
   step "Install mas (brew)" install_mas
   step "Install dasel (brew)" install_dasel
   step "Add zsh aliases (brew, mas)" ensure_zsh_aliases
   step "Ensure Apple Command Line Tools" ensure_xcode_clt
   step "Check MAS login" check_mas_login
-  step "Setup 1Password SSH Agent" check_1password_ssh_setup
-  step "Test GitHub SSH authentication" test_github_ssh
-  step "Clone repository" clone_repository
+  step "Clone repository (HTTPS)" clone_repository
 
   log "Bootstrap complete. Open a new shell (or 'exec zsh -l') to load aliases."
   log "Next: cd macos-setup && make install"

--- a/docs/1password-as-ssh-agent.md
+++ b/docs/1password-as-ssh-agent.md
@@ -1,0 +1,99 @@
+# Using 1Password as Your SSH Agent on macOS
+
+This repo is **public**, so `bootstrap.sh` clones it over plain HTTPS and
+needs no SSH key, no SSH agent, and no GitHub SSH authentication. The
+1Password SSH-agent walkthrough that `bootstrap.sh` used to perform
+inline has moved here, because the knowledge is still useful whenever you
+*do* need SSH auth — pushing to this repo, cloning a private repo, or
+authenticating to any other SSH host.
+
+1Password can act as your SSH agent: it holds your private keys in an
+encrypted vault and hands them to `ssh` on demand (gated by Touch ID /
+your vault unlock), so the private key never sits unencrypted on disk.
+
+> Juggling **multiple** GitHub accounts (e.g. work and personal) that
+> both live on `github.com`? Start here for the base setup, then see
+> [Configuring 1Password SSH Agent for Multiple GitHub Accounts on
+> macOS](CONFIGURING_1PASSWORD_SSH_AGENT_FOR_MULTIPLE_GITHUB_ACCOUNTS_ON_MACOS.md)
+> for the host-alias / bookmark layer on top.
+
+## Prerequisites
+
+- The 1Password 8 desktop app, installed and signed in. (Install it
+  with `brew install --cask 1password`, or via the `01-security`
+  Install category — `make security`.)
+- An SSH key stored in 1Password's **Private** vault. 1Password can
+  generate one for you (New Item → SSH Key) and, during creation, add
+  the matching public key to your GitHub account.
+
+## 1. Enable the 1Password SSH agent
+
+1. Open **1Password → Settings → Developer**.
+2. Enable **"Use the SSH agent"**.
+3. Make sure your SSH key lives in the **Private** vault. (Multiple
+   `[[ssh-keys]]` sections pointing at *different* vaults do not load
+   reliably — keep all keys in `Private`.)
+
+## 2. Point the agent at your vault (`agent.toml`)
+
+Create the agent config so the agent offers keys from your Private
+vault:
+
+```bash
+mkdir -p ~/.config/1Password/ssh
+printf '[[ssh-keys]]\nvault = "Private"\n' > ~/.config/1Password/ssh/agent.toml
+```
+
+The resulting `~/.config/1Password/ssh/agent.toml`:
+
+```toml
+[[ssh-keys]]
+vault = "Private"
+```
+
+## 3. Point `ssh` at the 1Password agent socket (`~/.ssh/config`)
+
+Make sure `~/.ssh/config` contains the following (create the file if it
+does not exist, mode `600`):
+
+```text
+Host *
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+```
+
+This tells every `ssh` invocation to talk to the 1Password agent socket
+instead of the default `ssh-agent`.
+
+## 4. Verify the agent can see your key(s)
+
+```bash
+sock=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+SSH_AUTH_SOCK="$sock" ssh-add -l
+```
+
+You should see your key listed. Then confirm GitHub authentication:
+
+```bash
+ssh -T git@github.com
+```
+
+GitHub responds with the username associated with the key — e.g.
+`Hi <username>! You've successfully authenticated...` — confirming the
+correct key was offered.
+
+## When you need this
+
+- **Pushing** commits to this repo (HTTPS clone is read-only without a
+  credential; SSH is the simplest write path).
+- **Cloning private repos** that HTTPS-without-a-token can't reach.
+- **Any other SSH host** (servers, other Git hosts) where you'd rather
+  1Password hold the key than have it unencrypted on disk.
+
+## See also
+
+- [Configuring 1Password SSH Agent for Multiple GitHub Accounts on
+  macOS](CONFIGURING_1PASSWORD_SSH_AGENT_FOR_MULTIPLE_GITHUB_ACCOUNTS_ON_MACOS.md)
+  — the host-alias / bookmark layer for two-or-more accounts on
+  `github.com`.
+- [Bootstrapping Alternatives](BOOTSTRAP.md) — other ways to bootstrap
+  (manual SSH-key clone, fresh key generation, HTTPS + PAT).

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,17 +1,28 @@
 # Bootstrapping Alternatives
 
-This doc collects other ways to bootstrap if you don't want to use the main two scripts.
+This doc collects other ways to bootstrap if you don't want to use the
+main `bootstrap.sh` script.
+
+This repo is **public**, so the default path needs no SSH key at all:
+`bootstrap.sh` clones it over HTTPS (see the Quick Start in the README).
+The SSH-based options below remain useful when you need to **push** to
+this repo or clone a **private** repo. For the full 1Password SSH-agent
+setup, see [1password-as-ssh-agent.md](1password-as-ssh-agent.md).
 
 ## A. Use 1Password SSH keys (AirDrop) and clone manually
+
 1. AirDrop your keys to the new Mac:
+
    ```bash
    mkdir -p ~/.ssh && chmod 700 ~/.ssh
    # Save these files:
    ~/.ssh/github_id_ed25519       # chmod 600
    ~/.ssh/github_id_ed25519.pub   # chmod 644
    ```
+
 2. Add 1Password SSH agent to `~/.ssh/config`:
-   ```
+
+   ```text
    Host github.com
      IdentityAgent "~/.1password/agent.sock"
      AddKeysToAgent yes
@@ -21,19 +32,23 @@ This doc collects other ways to bootstrap if you don't want to use the main two 
      AddKeysToAgent yes
      UseKeychain yes
    ```
+
 3. Install Apple CLT, Homebrew, and mas as needed, then clone the
    repository and run `make install`.
 
 ## B. Generate a fresh SSH key
+
 ```bash
 xcode-select --install
 ssh-keygen -t ed25519 -C "evoskamp" -f ~/.ssh/github_id_ed25519
 chmod 600 ~/.ssh/github_id_ed25519
 chmod 644 ~/.ssh/github_id_ed25519.pub
-pbcopy < ~/.ssh/github_id_ed25519.pub   # Add to GitHub → Settings → SSH and GPG keys
+# Copy the public key, then add it at GitHub → Settings → SSH and GPG keys
+pbcopy < ~/.ssh/github_id_ed25519.pub
 ```
 
 ## C. HTTPS clone with a personal access token (PAT)
+
 ```bash
 xcode-select --install
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -48,6 +48,21 @@ provisioning macOS with this repo.
   `make asdf-plugins-init` then `make asdf-pin-latest`
   and `make asdf-install`.
 
+## SSH / Credentials (Reference)
+
+The repo is public and `bootstrap.sh` clones it over HTTPS, so SSH is
+optional. These docs cover SSH auth for when you need it (pushing to
+this repo, cloning private repos):
+
+- **[Using 1Password as Your SSH Agent](1password-as-ssh-agent.md):**
+  Base setup — enable the agent, `agent.toml`, the `~/.ssh/config`
+  socket, and verification.
+- **[1Password SSH Agent for Multiple GitHub Accounts](CONFIGURING_1PASSWORD_SSH_AGENT_FOR_MULTIPLE_GITHUB_ACCOUNTS_ON_MACOS.md):**
+  The host-alias / bookmark layer for two-or-more accounts on
+  `github.com`.
+- **[Bootstrapping Alternatives](BOOTSTRAP.md):** Manual SSH-key clone,
+  fresh key generation, and HTTPS + PAT.
+
 ## Related
 
 - [ChatGPT Session Prompt](./CHATGPT.md)


### PR DESCRIPTION
Closes #3.

## Summary

The repo is now public, so bootstrapping needs no SSH key, no 1Password SSH agent, and no GitHub SSH auth — a plain HTTPS clone suffices.

**`bootstrap.sh`:**
- Drop the 1Password cask install (it still arrives via `make security`; it's just no longer a bootstrap prerequisite).
- Drop the interactive 1Password SSH-agent walkthrough and the GitHub SSH auth test.
- Clone over `https://github.com/TheVoskamps/macos-setup.git` instead of the `git@github.com:` SSH form.

**Knowledge preserved (not deleted):**
- New `docs/1password-as-ssh-agent.md` captures the 1Password-as-SSH-agent setup the bootstrap used to walk through — still useful for pushing to this repo or cloning private repos — cross-linked to the existing multiple-accounts doc.

**Swept stale references** (the change makes these wrong):
- `README.md`: "what the bootstrap does" list + Requirements section (no 1Password-by-bootstrap, no SSH-access requirement).
- `docs/BOOTSTRAP.md`: noted HTTPS is now the default path; also cleaned its pre-existing markdownlint errors.
- `docs/INDEX.md`: added an SSH/Credentials reference section.
- `CLAUDE.md`: fixed the stale bootstrap one-liner.

## Scope note

The claude-config install (the other half of the issue) **already** clones over HTTPS for fresh installs — verified in `scripts/claude_repo_setup.sh` (`install_fresh_clone` / `migrate_and_clone` both use `CLAUDE_REPO_URL_HTTPS`). Its opt-in SSH / `hostname=` machinery (for pre-existing SSH clones and per-machine identities) is intentionally left unchanged.

## Test plan

- [x] `bash -n bootstrap.sh` passes.
- [x] All touched markdown lints clean (`markdownlint-cli2`, 0 errors).
- [x] No script/test references the removed functions (`install_1password_via_brew`, `check_1password_ssh_setup`, `test_github_ssh`).
- [ ] Manual: run `bootstrap.sh` on a fresh-ish machine and confirm the HTTPS clone completes without credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)