### PR TITLE
Make Hammerspoon reload robust when IPC is down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -952,15 +952,23 @@ former in-repo `logs/` directory. This is macOS-native
   falls back to an IPC-independent app relaunch
   (`killall Hammerspoon` + `open -a Hammerspoon`),
   which re-execs init.lua from the now-correct symlink
-  and brings IPC back up, then re-probes IPC to confirm.
-  If neither path works it prints a loud, multi-line
-  stderr WARNING naming the menubar "Reload Config"
-  manual step and `make ui` exits non-zero (it no
-  longer claims success with a soft `Note:`). The
-  command names it drives (`hs`, `pgrep`, `killall`,
-  `open`) and the post-relaunch settle delay
-  (`HS_RELAUNCH_SETTLE`, default 5s) are env-overridable
-  so `scripts/test/hammerspoon_reload_test.sh` can stub
+  and brings IPC back up, then confirms with a
+  read-only liveness probe (`hs -c "true"`, NOT a second
+  `hs.reload()`). The confirmation is a probe-with-retry
+  loop, not a single fixed sleep: it polls every
+  `HS_RELAUNCH_INTERVAL` seconds (default 1s) for up to a
+  bounded `HS_RELAUNCH_TIMEOUT` total (default 15s),
+  succeeding as soon as a probe passes, so a slow cold
+  launch no longer false-negatives. If neither path
+  works it prints a loud, multi-line stderr WARNING
+  naming the menubar "Reload Config" manual step and
+  `make ui` exits non-zero (it no longer claims success
+  with a soft `Note:`). The command names it drives
+  (`hs`, `pgrep`, `killall`, `open`) and the retry-loop
+  timing (`HS_RELAUNCH_INTERVAL` / `HS_RELAUNCH_TIMEOUT`;
+  the legacy `HS_RELAUNCH_SETTLE` is still honored as an
+  alias for the interval) are env-overridable so
+  `scripts/test/hammerspoon_reload_test.sh` can stub
   them; sourcing the script (rather than executing it)
   returns early before the symlink work, exposing only
   those vars and `reload_hammerspoon`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -938,6 +938,32 @@ former in-repo `logs/` directory. This is macOS-native
 - Backs up existing files before symlinking
 - Also configures Ctrl+1-9 desktop switching
   shortcuts via `spaces_shortcuts_setup.sh`
+- After re-pointing the symlinks, if Hammerspoon is
+  running (gated on `pgrep`), `hammerspoon_setup.sh`
+  reloads it via the `reload_hammerspoon` function
+  (issue #18). It is robust against an IPC
+  chicken-and-egg: `hs.ipc`'s message port is brought
+  up by `require("hs.ipc")` INSIDE init.lua, so when
+  init.lua is broken or has never loaded from the
+  current checkout (e.g. a stale symlink) the IPC port
+  is down — yet `hs -c "hs.reload()"` IS the IPC path.
+  `reload_hammerspoon` tries IPC first (surfacing the
+  real error, not swallowing stderr); on failure it
+  falls back to an IPC-independent app relaunch
+  (`killall Hammerspoon` + `open -a Hammerspoon`),
+  which re-execs init.lua from the now-correct symlink
+  and brings IPC back up, then re-probes IPC to confirm.
+  If neither path works it prints a loud, multi-line
+  stderr WARNING naming the menubar "Reload Config"
+  manual step and `make ui` exits non-zero (it no
+  longer claims success with a soft `Note:`). The
+  command names it drives (`hs`, `pgrep`, `killall`,
+  `open`) and the post-relaunch settle delay
+  (`HS_RELAUNCH_SETTLE`, default 5s) are env-overridable
+  so `scripts/test/hammerspoon_reload_test.sh` can stub
+  them; sourcing the script (rather than executing it)
+  returns early before the symlink work, exposing only
+  those vars and `reload_hammerspoon`
 
 ## Key Scripts
 
@@ -951,7 +977,7 @@ former in-repo `logs/` directory. This is macOS-native
 | `shell_setup.sh` | Configures zsh, Oh My Zsh; aggregates `aliases.zsh` |
 | `vscode_extensions.sh` | Installs VS Code extensions |
 | `vscode_setup.sh` | Symlinks VS Code `settings.json` (single-winner) |
-| `hammerspoon_setup.sh` | Symlinks Hammerspoon config and modules |
+| `hammerspoon_setup.sh` | Symlinks HS config; robust reload (IPC + relaunch) |
 | `spaces_shortcuts_setup.sh` | Configures Ctrl+1-9 desktop shortcuts |
 | `msmtp_setup.sh` | Generates ~/.msmtprc from config.toml [mailer] values |
 | `claude_repo_setup.sh` | Clone/update ~/.claude/; sync plugins.sh |

--- a/README.md
+++ b/README.md
@@ -214,7 +214,17 @@ its consolidated `config.toml` in the external host tier,
   `workspaces.json` symlinked via `resolve_file`;
   `modules/` directory (including `apps/` launchers)
   symlinked via `resolve_dir`; desktop switching
-  shortcuts configured via `spaces_shortcuts_setup.sh`
+  shortcuts configured via `spaces_shortcuts_setup.sh`.
+  If Hammerspoon is already running, the setup reloads
+  it: it tries the IPC reload first and, if that fails
+  (e.g. a stale `init.lua` symlink left the `hs.ipc`
+  message port down), falls back to relaunching the app
+  so init.lua re-loads from the corrected symlink. If
+  the reload still can't be confirmed it prints a loud
+  warning telling you to reload manually from the
+  menubar (Hammerspoon icon → Reload Config) and `make
+  ui` exits non-zero rather than silently leaving your
+  hotkeys dead
 - **AWS CDK**: Config via `resolve_file` for `.cdk.json`
 - **Shell Environment**: Oh My Zsh themes and plugins;
   `aliases.zsh` aggregated across all tiers (default +

--- a/scripts/hammerspoon_setup.sh
+++ b/scripts/hammerspoon_setup.sh
@@ -6,6 +6,80 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 HAMMERSPOON_DIR="$HOME/.hammerspoon"
 
+# Commands the reload path drives, overridable so tests can stub them.
+HS="${HS:-hs}"
+PGREP="${PGREP:-pgrep}"
+KILLALL="${KILLALL:-killall}"
+OPEN="${OPEN:-open}"
+# Seconds to wait for a relaunched Hammerspoon to bring its IPC port back
+# up before re-probing. Overridable so tests don't have to really wait.
+HS_RELAUNCH_SETTLE="${HS_RELAUNCH_SETTLE:-5}"
+
+# reload_hammerspoon: apply the freshly-repointed symlinks to a RUNNING
+# Hammerspoon, robustly and loudly.
+#
+# Chicken-and-egg problem (issue #18): hs.ipc's message port is set up by
+# `require("hs.ipc")` INSIDE init.lua. When init.lua is broken or has never
+# loaded from the current checkout (e.g. a stale symlink), the IPC port is
+# down -- but `hs -c "hs.reload()"` IS the IPC path, so the one mechanism
+# used to reload is the one that cannot work in exactly the broken state
+# where reloading matters most.
+#
+# Strategy: try IPC first (showing its real error, not swallowing it); on
+# failure fall back to an IPC-independent app relaunch (killall + open),
+# which re-execs init.lua from the now-correct symlink and brings IPC back
+# up; re-probe IPC after the relaunch settles to confirm. If no path
+# works, emit a loud warning with the manual-reload instruction and return
+# non-zero rather than claiming success.
+#
+# The caller guards on Hammerspoon actually running, so this never
+# launches Hammerspoon on a machine where it was deliberately not running.
+reload_hammerspoon() {
+    # 1. Try IPC. Do NOT discard stderr -- the real error
+    #    ("can't access Hammerspoon message port ...; is it running with
+    #    the ipc module loaded?") is the signal the user needs.
+    if "$HS" -c "hs.reload()"; then
+        echo "Hammerspoon config reloaded (via IPC)"
+        return 0
+    fi
+
+    echo "IPC reload failed; falling back to relaunching Hammerspoon..."
+
+    # 2. IPC-independent fallback: relaunch the app. A fresh launch
+    #    re-execs init.lua from the (now-correct) symlink and brings IPC
+    #    back up. AppleScript ('execute lua code') is NOT a reliable
+    #    fallback -- it is disabled by default in default/.hammerspoon
+    #    (hs.allowAppleScript(true) is not set), so relaunch is the only
+    #    path that reliably works when init.lua has not loaded.
+    "$KILLALL" Hammerspoon 2>/dev/null || true
+    "$OPEN" -a Hammerspoon
+
+    # Give the relaunched app time to load init.lua and bring IPC up,
+    # then re-probe via IPC to confirm it actually came back.
+    sleep "$HS_RELAUNCH_SETTLE"
+    if "$HS" -c "hs.reload()"; then
+        echo "Hammerspoon relaunched and config reloaded"
+        return 0
+    fi
+
+    # 3. Neither path worked. Make the failure loud, not a soft Note.
+    echo "" >&2
+    echo "========================================================================" >&2
+    echo "WARNING: Could not reload Hammerspoon automatically." >&2
+    echo "The symlinks are updated, but the running Hammerspoon has NOT picked" >&2
+    echo "them up, so your hotkeys may be dead until you reload manually." >&2
+    echo "" >&2
+    echo "  -> Reload now from the menubar: Hammerspoon icon -> Reload Config" >&2
+    echo "========================================================================" >&2
+    echo "" >&2
+    return 1
+}
+
+# When sourced (e.g. by the unit test) rather than executed, stop here:
+# expose the overridable command vars and reload_hammerspoon, but do not
+# run the symlink setup or even source config_common.sh.
+(return 0 2>/dev/null) && return 0
+
 source "$SCRIPT_DIR/config_common.sh"
 
 echo "Setting up Hammerspoon configuration..."
@@ -104,7 +178,10 @@ fi
 echo ""
 echo "Hammerspoon configuration setup complete!"
 
-# Reload Hammerspoon if it's running
-if pgrep -q Hammerspoon; then
-    hs -c "hs.reload()" 2>/dev/null && echo "Hammerspoon config reloaded" || echo "Note: Could not reload Hammerspoon (is the IPC module enabled?)"
+# Reload Hammerspoon if it's running. Keep the pgrep guard so we never
+# launch Hammerspoon on a machine where it was deliberately not running.
+if "$PGREP" -q Hammerspoon; then
+    # Don't let `set -e` abort on a failed reload before its loud warning
+    # has been printed; surface the failure as this script's exit status.
+    reload_hammerspoon || exit $?
 fi

--- a/scripts/hammerspoon_setup.sh
+++ b/scripts/hammerspoon_setup.sh
@@ -11,9 +11,15 @@ HS="${HS:-hs}"
 PGREP="${PGREP:-pgrep}"
 KILLALL="${KILLALL:-killall}"
 OPEN="${OPEN:-open}"
-# Seconds to wait for a relaunched Hammerspoon to bring its IPC port back
-# up before re-probing. Overridable so tests don't have to really wait.
-HS_RELAUNCH_SETTLE="${HS_RELAUNCH_SETTLE:-5}"
+# Post-relaunch IPC confirmation is a probe-with-retry loop, not a single
+# fixed sleep: a cold launch can take a while to bring its IPC port up, so
+# a single 5s sleep + one probe used to false-negative. Instead we poll
+# every HS_RELAUNCH_INTERVAL seconds for up to HS_RELAUNCH_TIMEOUT seconds,
+# succeeding as soon as a probe passes. Both are env-overridable so tests
+# don't have to really wait. HS_RELAUNCH_SETTLE is honored for backward
+# compatibility as an alias for the per-probe interval.
+HS_RELAUNCH_INTERVAL="${HS_RELAUNCH_INTERVAL:-${HS_RELAUNCH_SETTLE:-1}}"
+HS_RELAUNCH_TIMEOUT="${HS_RELAUNCH_TIMEOUT:-15}"
 
 # reload_hammerspoon: apply the freshly-repointed symlinks to a RUNNING
 # Hammerspoon, robustly and loudly.
@@ -28,9 +34,10 @@ HS_RELAUNCH_SETTLE="${HS_RELAUNCH_SETTLE:-5}"
 # Strategy: try IPC first (showing its real error, not swallowing it); on
 # failure fall back to an IPC-independent app relaunch (killall + open),
 # which re-execs init.lua from the now-correct symlink and brings IPC back
-# up; re-probe IPC after the relaunch settles to confirm. If no path
-# works, emit a loud warning with the manual-reload instruction and return
-# non-zero rather than claiming success.
+# up; then poll IPC with a read-only liveness probe (retry up to a bounded
+# timeout) to confirm it actually came back. If no path works, emit a loud
+# warning with the manual-reload instruction and return non-zero rather
+# than claiming success.
 #
 # The caller guards on Hammerspoon actually running, so this never
 # launches Hammerspoon on a machine where it was deliberately not running.
@@ -54,13 +61,36 @@ reload_hammerspoon() {
     "$KILLALL" Hammerspoon 2>/dev/null || true
     "$OPEN" -a Hammerspoon
 
-    # Give the relaunched app time to load init.lua and bring IPC up,
-    # then re-probe via IPC to confirm it actually came back.
-    sleep "$HS_RELAUNCH_SETTLE"
-    if "$HS" -c "hs.reload()"; then
-        echo "Hammerspoon relaunched and config reloaded"
-        return 0
+    # The relaunched app's IPC port comes up only once it has loaded
+    # init.lua, which can take a while on a cold launch. Poll for IPC
+    # liveness every HS_RELAUNCH_INTERVAL seconds up to a bounded
+    # HS_RELAUNCH_TIMEOUT total, succeeding as soon as a probe passes
+    # (rather than a single fixed sleep + one probe, which false-negatives
+    # on a slow launch). The probe is a READ-ONLY liveness command
+    # (`hs -c "true"`), NOT a second hs.reload() -- the relaunch already
+    # re-loaded init.lua from the corrected symlink, so a second reload
+    # would be redundant; we only need to confirm IPC is back up.
+    #
+    # Derive a whole-number attempt cap from the timeout/interval so the
+    # loop is bounded even when the interval is 0 (as the unit test sets
+    # it, to avoid real sleeping). With a 0 interval we still probe
+    # HS_RELAUNCH_TIMEOUT+1 times; with a positive interval we probe
+    # ceil(timeout/interval)+1 times, covering t=0 through t=timeout.
+    local interval="$HS_RELAUNCH_INTERVAL" timeout="$HS_RELAUNCH_TIMEOUT" attempts
+    if (( interval > 0 )); then
+        attempts=$(( (timeout + interval - 1) / interval + 1 ))
+    else
+        attempts=$(( timeout + 1 ))
     fi
+    local n
+    for (( n = 0; n < attempts; n++ )); do
+        if "$HS" -c "true"; then
+            echo "Hammerspoon relaunched and config reloaded"
+            return 0
+        fi
+        # Don't sleep after the final probe -- nothing follows it.
+        (( n < attempts - 1 )) && sleep "$interval"
+    done
 
     # 3. Neither path worked. Make the failure loud, not a soft Note.
     echo "" >&2

--- a/scripts/test/hammerspoon_reload_test.sh
+++ b/scripts/test/hammerspoon_reload_test.sh
@@ -14,7 +14,9 @@
 # reload_hammerspoon now:
 #   1. tries IPC WITHOUT discarding stderr (the real error is the signal),
 #   2. on IPC failure relaunches the app (killall + open) -- IPC-independent,
-#      so it works even when init.lua never loaded -- and re-probes IPC,
+#      so it works even when init.lua never loaded -- and confirms the app
+#      came back with a READ-ONLY liveness probe (`hs -c "true"`, NOT a
+#      second hs.reload()), polled with retry up to a bounded timeout,
 #   3. if neither path works, emits a LOUD warning (to stderr) with the
 #      manual-reload instruction and returns non-zero (does NOT claim
 #      success).
@@ -64,23 +66,32 @@ STUB
   chmod +x "$path"
 }
 
-# An `hs` stub whose exit code is read fresh from \$TMP/hs_rc on EACH call,
-# so scenario 2 can make the first IPC probe fail and the post-relaunch
-# probe succeed. Emits the real-world IPC error text on the failing path so
-# we can assert it is surfaced (not swallowed).
+# An `hs` stub driven by a SEQUENCE of exit codes (one per line in
+# $TMP/hs_rc_seq), consumed one per call. This models the retry loop: e.g.
+# "1 1 1 0" makes the initial IPC reload fail, the first two post-relaunch
+# liveness probes fail, and the third probe succeed. The LAST code in the
+# sequence repeats for any further calls (so a "1\n1" sequence keeps
+# failing forever, used by the give-up scenario). Each call records its
+# argv to calls.log and, on a non-zero code, emits the real-world IPC error
+# text so we can assert it is surfaced (not swallowed). The per-call index
+# lives in $TMP/hs_call_n.
 write_hs_stub() {
   cat > "$TMP/hs" <<STUB
 #!/usr/bin/env bash
-rc="\$(cat "$TMP/hs_rc")"
 echo "hs \$*" >> "$TMP/calls.log"
+# Determine which call this is (0-based) and bump the counter.
+n=0
+[[ -f "$TMP/hs_call_n" ]] && n="\$(cat "$TMP/hs_call_n")"
+echo "\$(( n + 1 ))" > "$TMP/hs_call_n"
+# Read the rc sequence into an array (avoid mapfile -- macOS ships bash 3.2).
+seq=()
+while IFS= read -r line; do seq+=("\$line"); done < "$TMP/hs_rc_seq"
+# Pick the rc for this call; clamp to the last entry for overflow calls.
+idx="\$n"
+(( idx >= \${#seq[@]} )) && idx=\$(( \${#seq[@]} - 1 ))
+rc="\${seq[idx]}"
 if [[ "\$rc" != "0" ]]; then
   echo "can't access Hammerspoon message port Hammerspoon; is it running with the ipc module loaded?" >&2
-fi
-# After the first call, flip to the value in hs_rc_next (used by the
-# relaunch-succeeds scenario where the post-relaunch probe must pass).
-if [[ -f "$TMP/hs_rc_next" ]]; then
-  cp "$TMP/hs_rc_next" "$TMP/hs_rc"
-  rm -f "$TMP/hs_rc_next"
 fi
 exit "\$rc"
 STUB
@@ -101,25 +112,42 @@ ok "$(type -t reload_hammerspoon)" "function" \
 
 # Drive reload_hammerspoon with stubbed commands. Echoes
 # "<rc>|<combined-output>" and leaves $TMP/calls.log for sequence asserts.
+# The first arg is a space-separated SEQUENCE of `hs` exit codes (one per
+# call, last repeats); e.g. "0" = IPC reload succeeds first try, "1 0" =
+# IPC reload fails then the first liveness probe passes, "1 1 1 0" = IPC
+# reload fails and the liveness probe passes on its third try, "1 1" = IPC
+# reload fails and every probe fails (give-up path).
+#
+# HS_RELAUNCH_INTERVAL=0 keeps the retry loop from really sleeping; the
+# bounded HS_RELAUNCH_TIMEOUT still caps the number of attempts.
 run_reload() {
-  # args: <first-hs-rc> <hs-rc-after-first-call> <killall-rc> <open-rc>
+  # args: <hs-rc-sequence> <killall-rc> <open-rc> [hs_relaunch_timeout]
   : > "$TMP/calls.log"
-  printf '%s' "$1" > "$TMP/hs_rc"
-  printf '%s' "$2" > "$TMP/hs_rc_next"
+  : > "$TMP/hs_call_n"
+  printf '0' > "$TMP/hs_call_n"
+  printf '%s\n' $1 > "$TMP/hs_rc_seq"
   write_hs_stub
-  write_stub "$TMP/killall" "$3"
-  write_stub "$TMP/open" "$4"
+  write_stub "$TMP/killall" "$2"
+  write_stub "$TMP/open" "$3"
+  local timeout="${4:-15}"
   local out rc
   out="$(HS="$TMP/hs" KILLALL="$TMP/killall" OPEN="$TMP/open" \
-    HS_RELAUNCH_SETTLE=0 reload_hammerspoon 2>&1)"
+    HS_RELAUNCH_INTERVAL=0 HS_RELAUNCH_TIMEOUT="$timeout" \
+    reload_hammerspoon 2>&1)"
   rc=$?
   printf '%s|%s' "$rc" "$out"
+}
+
+# count_lines_matching <fixed-needle>: how many lines of calls.log contain
+# the needle (used to assert call counts, e.g. exactly one hs.reload()).
+count_lines_matching() {
+  grep -cF -- "$1" "$TMP/calls.log" 2>/dev/null || echo 0
 }
 
 echo "=== hammerspoon reload_hammerspoon tests ==="
 
 # --- Scenario 1: IPC reload succeeds on the first try ---
-res="$(run_reload 0 0 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+res="$(run_reload 0 0 0)"; rc="${res%%|*}"; out="${res#*|}"
 ok "$rc" "0" "IPC succeeds -> reload returns 0"
 ok_contains "$out" "reloaded (via IPC)" "IPC success -> reports IPC reload"
 ok_absent "$(cat "$TMP/calls.log")" "killall" \
@@ -127,10 +155,10 @@ ok_absent "$(cat "$TMP/calls.log")" "killall" \
 ok_absent "$(cat "$TMP/calls.log")" "open" \
   "IPC success -> does NOT relaunch (no open)"
 
-# --- Scenario 2: IPC fails, relaunch + re-probe succeeds ---
-# First hs call fails (IPC down); after the failure the stub flips hs_rc to
-# 0 so the post-relaunch probe passes.
-res="$(run_reload 1 0 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+# --- Scenario 2: IPC fails, relaunch + read-only liveness probe succeeds ---
+# First hs call (the IPC reload) fails (IPC down); the post-relaunch
+# liveness probe then passes on its first try.
+res="$(run_reload "1 0" 0 0)"; rc="${res%%|*}"; out="${res#*|}"
 ok "$rc" "0" "IPC fails then relaunch works -> reload returns 0"
 ok_contains "$out" "relaunched and config reloaded" \
   "relaunch path -> reports relaunch+reload success"
@@ -141,10 +169,33 @@ ok_contains "$(cat "$TMP/calls.log")" "open -a Hammerspoon" \
 # The real IPC error must be surfaced, not swallowed (the core bug).
 ok_contains "$out" "can't access Hammerspoon message port" \
   "IPC failure -> the real IPC error is surfaced (stderr not swallowed)"
+# The post-relaunch confirmation is a READ-ONLY liveness probe, not a
+# second hs.reload(): there must be exactly ONE hs.reload() (the initial
+# IPC attempt) and at least one read-only `hs -c true` confirmation.
+ok "$(count_lines_matching 'hs -c hs.reload()')" "1" \
+  "relaunch path -> confirmation does NOT trigger a second hs.reload()"
+ok_contains "$(cat "$TMP/calls.log")" "hs -c true" \
+  "relaunch path -> confirmation uses a read-only liveness probe (hs -c true)"
 
-# --- Scenario 3: IPC fails AND post-relaunch probe also fails ---
-# hs fails on every call (hs_rc stays 1, hs_rc_next also 1).
-res="$(run_reload 1 1 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+# --- Scenario 2b: post-relaunch probe needs RETRIES before IPC is back ---
+# The IPC reload fails, then the liveness probe fails twice (cold launch
+# still bringing IPC up) and passes on the third attempt. With a bounded
+# timeout the loop must keep polling and ultimately succeed.
+res="$(run_reload "1 1 1 0" 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+ok "$rc" "0" "probe retries then succeeds -> reload returns 0"
+ok_contains "$out" "relaunched and config reloaded" \
+  "retry path -> reports relaunch+reload success once a probe passes"
+# 1 initial reload probe is hs.reload(); the 3 liveness probes are hs -c true.
+ok "$(count_lines_matching 'hs -c true')" "3" \
+  "retry path -> polls the read-only probe until it passes (3 attempts)"
+ok "$(count_lines_matching 'hs -c hs.reload()')" "1" \
+  "retry path -> still only one hs.reload() (the initial IPC attempt)"
+
+# --- Scenario 3: IPC fails AND every post-relaunch probe also fails ---
+# hs fails on every call; the bounded retry loop gives up after exhausting
+# its attempts. A small timeout keeps the test fast while still exercising
+# more than one probe attempt.
+res="$(run_reload "1 1" 0 0 3)"; rc="${res%%|*}"; out="${res#*|}"
 ok "$( [[ "$rc" != "0" ]] && echo nonzero || echo zero )" "nonzero" \
   "both paths fail -> reload returns non-zero (does NOT claim success)"
 ok_contains "$out" "WARNING: Could not reload Hammerspoon" \
@@ -153,6 +204,10 @@ ok_contains "$out" "Reload Config" \
   "both paths fail -> warning includes the manual menubar-reload instruction"
 ok_absent "$out" "Note: Could not reload" \
   "both paths fail -> no soft 'Note:' line (old buried failure mode is gone)"
+# The give-up path must have actually retried the bounded probe loop more
+# than once before warning (timeout=3, interval=0 -> 4 liveness probes).
+ok "$(count_lines_matching 'hs -c true')" "4" \
+  "give-up path -> retries the read-only probe up to the bounded timeout"
 
 # --- Regression: the source no longer swallows the IPC stderr ---
 ok_absent "$(cat "$SETUP")" 'hs -c "hs.reload()" 2>/dev/null' \

--- a/scripts/test/hammerspoon_reload_test.sh
+++ b/scripts/test/hammerspoon_reload_test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# Tests for the robust Hammerspoon reload path (issue #18).
+#
+# The chicken-and-egg bug: hs.ipc's message port is set up by
+# `require("hs.ipc")` INSIDE init.lua, so when init.lua is broken or has
+# never loaded from the current checkout (a stale symlink), the IPC port is
+# down -- and `hs -c "hs.reload()"` IS the IPC path, so the one mechanism
+# the script used to reload is the one that cannot work in exactly the
+# broken state where reloading matters most. The old code also swallowed
+# the real IPC error (`2>/dev/null`) and printed a soft `Note:` that got
+# lost in the `make ui` output wall.
+#
+# reload_hammerspoon now:
+#   1. tries IPC WITHOUT discarding stderr (the real error is the signal),
+#   2. on IPC failure relaunches the app (killall + open) -- IPC-independent,
+#      so it works even when init.lua never loaded -- and re-probes IPC,
+#   3. if neither path works, emits a LOUD warning (to stderr) with the
+#      manual-reload instruction and returns non-zero (does NOT claim
+#      success).
+#
+# These tests source scripts/hammerspoon_setup.sh (which returns early when
+# sourced, exposing only the command-override vars + reload_hammerspoon) and
+# drive reload_hammerspoon with stub `hs`/`killall`/`open` binaries via the
+# HS/KILLALL/OPEN env overrides, recording each invocation so we can assert
+# the call sequence per scenario without a real Hammerspoon.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SETUP="$REPO_ROOT/scripts/hammerspoon_setup.sh"
+
+pass=0
+fail=0
+ok() {
+  # ok <actual> <want> <label>
+  if [[ "$1" == "$2" ]]; then echo "PASS: $3"; ((pass++)); else echo "FAIL: $3 -- got [$1] want [$2]"; ((fail++)); fi
+}
+ok_contains() {
+  # ok_contains <haystack> <needle> <label>
+  if grep -qF -- "$2" <<<"$1"; then echo "PASS: $3"; ((pass++)); else echo "FAIL: $3 -- output missing [$2]"; ((fail++)); fi
+}
+ok_absent() {
+  # ok_absent <haystack> <needle> <label>
+  if grep -qF -- "$2" <<<"$1"; then echo "FAIL: $3 -- output unexpectedly contains [$2]"; ((fail++)); else echo "PASS: $3"; ((pass++)); fi
+}
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+# Write a stub command at $1 that appends its name+args to $TMP/calls.log,
+# emits a recognizable line on stderr, and exits with $2.
+write_stub() {
+  local path="$1" rc="$2" name
+  name="$(basename "$path")"
+  cat > "$path" <<STUB
+#!/usr/bin/env bash
+echo "$name \$*" >> "$TMP/calls.log"
+echo "[$name-stub] called with: \$*" >&2
+exit $rc
+STUB
+  chmod +x "$path"
+}
+
+# An `hs` stub whose exit code is read fresh from \$TMP/hs_rc on EACH call,
+# so scenario 2 can make the first IPC probe fail and the post-relaunch
+# probe succeed. Emits the real-world IPC error text on the failing path so
+# we can assert it is surfaced (not swallowed).
+write_hs_stub() {
+  cat > "$TMP/hs" <<STUB
+#!/usr/bin/env bash
+rc="\$(cat "$TMP/hs_rc")"
+echo "hs \$*" >> "$TMP/calls.log"
+if [[ "\$rc" != "0" ]]; then
+  echo "can't access Hammerspoon message port Hammerspoon; is it running with the ipc module loaded?" >&2
+fi
+# After the first call, flip to the value in hs_rc_next (used by the
+# relaunch-succeeds scenario where the post-relaunch probe must pass).
+if [[ -f "$TMP/hs_rc_next" ]]; then
+  cp "$TMP/hs_rc_next" "$TMP/hs_rc"
+  rm -f "$TMP/hs_rc_next"
+fi
+exit "\$rc"
+STUB
+  chmod +x "$TMP/hs"
+}
+
+# Source the script under test; the sourcing guard returns before any
+# symlink work or config_common.sh sourcing happens.
+# shellcheck disable=SC1090
+source "$SETUP"
+# The sourced script runs `set -e`; turn it back off so our `((pass++))`
+# arithmetic (which returns the pre-increment value, i.e. status 1 when the
+# counter is 0) does not abort the test harness mid-run.
+set +e
+
+ok "$(type -t reload_hammerspoon)" "function" \
+  "sourcing hammerspoon_setup.sh exposes reload_hammerspoon"
+
+# Drive reload_hammerspoon with stubbed commands. Echoes
+# "<rc>|<combined-output>" and leaves $TMP/calls.log for sequence asserts.
+run_reload() {
+  # args: <first-hs-rc> <hs-rc-after-first-call> <killall-rc> <open-rc>
+  : > "$TMP/calls.log"
+  printf '%s' "$1" > "$TMP/hs_rc"
+  printf '%s' "$2" > "$TMP/hs_rc_next"
+  write_hs_stub
+  write_stub "$TMP/killall" "$3"
+  write_stub "$TMP/open" "$4"
+  local out rc
+  out="$(HS="$TMP/hs" KILLALL="$TMP/killall" OPEN="$TMP/open" \
+    HS_RELAUNCH_SETTLE=0 reload_hammerspoon 2>&1)"
+  rc=$?
+  printf '%s|%s' "$rc" "$out"
+}
+
+echo "=== hammerspoon reload_hammerspoon tests ==="
+
+# --- Scenario 1: IPC reload succeeds on the first try ---
+res="$(run_reload 0 0 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+ok "$rc" "0" "IPC succeeds -> reload returns 0"
+ok_contains "$out" "reloaded (via IPC)" "IPC success -> reports IPC reload"
+ok_absent "$(cat "$TMP/calls.log")" "killall" \
+  "IPC success -> does NOT relaunch (no killall)"
+ok_absent "$(cat "$TMP/calls.log")" "open" \
+  "IPC success -> does NOT relaunch (no open)"
+
+# --- Scenario 2: IPC fails, relaunch + re-probe succeeds ---
+# First hs call fails (IPC down); after the failure the stub flips hs_rc to
+# 0 so the post-relaunch probe passes.
+res="$(run_reload 1 0 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+ok "$rc" "0" "IPC fails then relaunch works -> reload returns 0"
+ok_contains "$out" "relaunched and config reloaded" \
+  "relaunch path -> reports relaunch+reload success"
+ok_contains "$(cat "$TMP/calls.log")" "killall Hammerspoon" \
+  "relaunch path -> kills the running Hammerspoon"
+ok_contains "$(cat "$TMP/calls.log")" "open -a Hammerspoon" \
+  "relaunch path -> opens Hammerspoon afresh"
+# The real IPC error must be surfaced, not swallowed (the core bug).
+ok_contains "$out" "can't access Hammerspoon message port" \
+  "IPC failure -> the real IPC error is surfaced (stderr not swallowed)"
+
+# --- Scenario 3: IPC fails AND post-relaunch probe also fails ---
+# hs fails on every call (hs_rc stays 1, hs_rc_next also 1).
+res="$(run_reload 1 1 0 0)"; rc="${res%%|*}"; out="${res#*|}"
+ok "$( [[ "$rc" != "0" ]] && echo nonzero || echo zero )" "nonzero" \
+  "both paths fail -> reload returns non-zero (does NOT claim success)"
+ok_contains "$out" "WARNING: Could not reload Hammerspoon" \
+  "both paths fail -> emits a loud WARNING (not a soft Note:)"
+ok_contains "$out" "Reload Config" \
+  "both paths fail -> warning includes the manual menubar-reload instruction"
+ok_absent "$out" "Note: Could not reload" \
+  "both paths fail -> no soft 'Note:' line (old buried failure mode is gone)"
+
+# --- Regression: the source no longer swallows the IPC stderr ---
+ok_absent "$(cat "$SETUP")" 'hs -c "hs.reload()" 2>/dev/null' \
+  "source -> the old stderr-swallowing one-liner is gone"
+
+# --- Regression: the pgrep running-guard is preserved (issue #18 note) ---
+# The script must still gate the reload on Hammerspoon actually running, so
+# it never launches Hammerspoon where it was deliberately not running.
+ok_contains "$(cat "$SETUP")" 'PGREP" -q Hammerspoon' \
+  "source -> reload is still gated on a pgrep running-check"
+
+echo
+echo "---"
+echo "pass=$pass fail=$fail"
+if [[ $fail -eq 0 ]]; then
+  echo "All hammerspoon reload tests passed."
+  exit 0
+fi
+echo "Some hammerspoon reload tests FAILED."
+exit 1


### PR DESCRIPTION
## Summary

`scripts/hammerspoon_setup.sh` repoints the `~/.hammerspoon` symlinks and then reloads Hammerspoon via the IPC CLI (`hs -c "hs.reload()"`). That path fails silently in exactly the case where reloading matters most — a chicken-and-egg: `hs.ipc`'s message port is set up by `require("hs.ipc")` **inside** `init.lua`, so when `init.lua` is broken or has never loaded from the current checkout (e.g. a stale symlink after a repo move), the IPC port is down — but IPC is the one mechanism the script used to reload. The old code also swallowed the real error with `2>/dev/null` and printed a soft `Note:` that got lost in the `make ui` output wall, so `make ui` reported success while hotkeys silently stayed dead.

## What changed

Extracted the reload into a `reload_hammerspoon` function that:

1. **Tries IPC first, without discarding stderr** — the real error (`can't access Hammerspoon message port ...`) now surfaces instead of being swallowed.
2. **On IPC failure, falls back to an IPC-independent app relaunch** (`killall Hammerspoon` then `open -a Hammerspoon`), which re-execs `init.lua` from the now-correct symlink and brings IPC back up, then **re-probes IPC** after a settle delay to confirm it actually returned.
3. **If neither path works, emits a loud stderr WARNING** with the manual menubar-reload instruction and returns non-zero — it no longer claims success.

The `pgrep -q Hammerspoon` running-guard is preserved, so the relaunch never launches Hammerspoon on a machine where it was deliberately not running. AppleScript (`execute lua code`) is intentionally not used as the fallback because it is disabled by default in `default/.hammerspoon`.

The reload commands (`hs`/`pgrep`/`killall`/`open`) and the relaunch settle delay are made overridable via env vars (following the repo's existing `BREW="${BREW:-brew}"` convention), and a sourcing guard lets a unit test source the function without running the symlink setup.

## Tests

Added `scripts/test/hammerspoon_reload_test.sh` (16 assertions) covering all three scenarios — IPC success, IPC-fail→relaunch-success, and both-fail→loud-warning — plus regressions asserting the stderr-swallowing one-liner is gone and the `pgrep` guard is preserved. New test passes; the full existing `scripts/test/` suite (12 scripts + the `cr` zsh test) still passes.

Per the issue's acceptance criteria, the only path that cannot be exercised in CI is the by-hand verification on a machine where `init.lua` starts as a broken symlink.

References: #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)