### PR TITLE
Set HOMEBREW_NO_ASK to stop make update hanging on ask-mode prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,12 @@ make diagnose  # Run system diagnostics
 
 ### Automatic Post-Install Actions
 
+- `00-Install.core` -> Runs `scripts/core_setup.sh`:
+  sets computer/host names, and appends two grep-guarded
+  exports to `~/.zshrc` — `HOMEBREW_NO_AUTO_UPDATE=1`
+  and `HOMEBREW_NO_ASK=1` (the latter disables Homebrew
+  6.0+ interactive ask-mode so `make update` / `make
+  install` don't hang on a `[y/n]` prompt — issue #20)
 - `02-Install.ui` -> Runs Finder config and
   Hammerspoon setup
 - `03-Install.shell` -> Runs `scripts/shell_setup.sh`
@@ -433,6 +439,33 @@ skips their packages and exits 0 — issue #172). The
 trust is idempotent and conservative — a tap is trusted
 only if its own `tap` line still emits; the `BREW` env
 var overrides the brew binary used. See `docs/INSTALL.md`.
+
+A second Homebrew 6.0 quirk is **interactive ask-mode**
+(issue #20): 6.0 made a `Do you want to proceed? [y/n]`
+prompt the default for `install`/`upgrade`/`reinstall`
+(and, via `brew bundle`'s default upgrade, for `bundle`
+too), so an unattended `make update` / `make install`
+hangs forever with no TTY. `HOMEBREW_NO_ASK=1` disables
+it for every brew call with one lever. It is set in three
+scopes, because each has a distinct environment that the
+others don't reach:
+
+- **Interactive shell** — `scripts/core_setup.sh` (the
+  `00-Install.core` post-install action) appends a
+  grep-guarded `export HOMEBREW_NO_ASK=1` to `~/.zshrc`,
+  alongside the existing `HOMEBREW_NO_AUTO_UPDATE` export.
+- **Scheduled jobs** — `scripts/launchagent_runner.sh`
+  exports `HOMEBREW_NO_ASK=1` near the top. launchd does
+  NOT source `~/.zshrc`, so the interactive export never
+  reaches a LaunchAgent. Exporting it in the runner (not
+  the plist's `EnvironmentVariables`) means existing
+  schedules self-heal on the next repo pull with no
+  `make schedule-*` re-run, and it covers every job
+  routed through that single entry point.
+- **Bootstrap** — `bootstrap.sh` prefixes `HOMEBREW_NO_ASK=1`
+  onto its `mas` and `dasel` `brew install`/`upgrade`
+  lines, because bootstrap runs before `~/.zshrc` gains
+  the export.
 
 **Uninstall/** and **RemoveAndPurge/** files also
 aggregate across tiers, but with a narrower filter scope

--- a/README.md
+++ b/README.md
@@ -384,6 +384,15 @@ make unschedule-weekly
 LaunchAgents run in the user's login session, providing
 access to the macOS Keychain for email credentials.
 
+Scheduled jobs set `HOMEBREW_NO_ASK=1` so an unattended
+`make update` never hangs on Homebrew 6.0's interactive
+`Do you want to proceed? [y/n]` ask-mode prompt. The
+runner (`scripts/launchagent_runner.sh`) exports it
+directly, because launchd does not source `~/.zshrc`
+where the interactive export lives; existing schedules
+pick this up on the next repo pull with no
+`make schedule-*` re-run.
+
 #### Email Notifications
 
 Scheduled jobs can optionally send email reports instead

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -95,7 +95,9 @@ install_homebrew() {
 }
 
 install_mas() {
-  brew install mas || brew upgrade mas || true
+  # HOMEBREW_NO_ASK avoids the Homebrew 6.0+ interactive ask-mode prompt
+  # (issue #20); bootstrap runs before .zshrc gains the export.
+  HOMEBREW_NO_ASK=1 brew install mas || HOMEBREW_NO_ASK=1 brew upgrade mas || true
 }
 
 # dasel is the TOML query primitive every config.toml consumer relies on
@@ -112,7 +114,9 @@ install_mas() {
 # install must NOT be silently ignored. Idempotent: brew install/upgrade
 # is a no-op when dasel is already current.
 install_dasel() {
-  brew install dasel || brew upgrade dasel
+  # HOMEBREW_NO_ASK avoids the Homebrew 6.0+ interactive ask-mode prompt
+  # (issue #20); bootstrap runs before .zshrc gains the export.
+  HOMEBREW_NO_ASK=1 brew install dasel || HOMEBREW_NO_ASK=1 brew upgrade dasel
 
   if ! command -v dasel >/dev/null 2>&1; then
     err "dasel not on PATH after brew install/upgrade; config.toml reads require dasel v3."

--- a/scripts/core_setup.sh
+++ b/scripts/core_setup.sh
@@ -86,8 +86,24 @@ if [[ -f "$ZSHRC" ]]; then
     else
         echo "HOMEBREW_NO_AUTO_UPDATE already set in .zshrc"
     fi
+
+    # Disable Homebrew 6.0+ interactive ask-mode prompt. Homebrew 6.0
+    # made ask mode the default for install/upgrade/reinstall (and, via
+    # `brew bundle`'s default upgrade, for bundle too), so every such
+    # call blocks on a "Do you want to proceed? [y/n]" prompt. Setting
+    # HOMEBREW_NO_ASK covers all of them (and any future brew call) with
+    # one lever, so `make update` / `make install` no longer hang.
+    if ! grep -q "HOMEBREW_NO_ASK" "$ZSHRC"; then
+        echo "Adding HOMEBREW_NO_ASK=1 to .zshrc..."
+        echo "" >> "$ZSHRC"
+        echo "# Disable Homebrew interactive ask-mode prompt (Homebrew 6.0+)" >> "$ZSHRC"
+        echo "export HOMEBREW_NO_ASK=1" >> "$ZSHRC"
+        echo "HOMEBREW_NO_ASK added to .zshrc"
+    else
+        echo "HOMEBREW_NO_ASK already set in .zshrc"
+    fi
 else
-    echo "Warning: .zshrc not found, skipping HOMEBREW_NO_AUTO_UPDATE setup"
+    echo "Warning: .zshrc not found, skipping HOMEBREW_NO_AUTO_UPDATE / HOMEBREW_NO_ASK setup"
 fi
 
 echo "Core system configuration complete!"

--- a/scripts/launchagent_runner.sh
+++ b/scripts/launchagent_runner.sh
@@ -70,6 +70,19 @@
 
 set -euo pipefail
 
+# Disable Homebrew 6.0+ interactive ask-mode prompt for every scheduled
+# job (issue #20). Homebrew 6.0 made ask mode the default for
+# install/upgrade/reinstall (and, via `brew bundle`'s default upgrade,
+# for bundle too), so a `make update` running here would block on a
+# "Do you want to proceed? [y/n]" prompt with no controlling TTY and
+# hang indefinitely. launchd does NOT source ~/.zshrc, so the
+# interactive HOMEBREW_NO_ASK export added there by core_setup.sh never
+# reaches this runner — it must be set here as well. Exporting it in the
+# runner (rather than the plist's EnvironmentVariables) means existing
+# schedules self-heal on the next repo pull, with no `make schedule-*`
+# re-run, and covers every job that routes through this one entry point.
+export HOMEBREW_NO_ASK=1
+
 if [[ $# -lt 2 ]]; then
     cat >&2 <<'EOF'
 Usage:

--- a/scripts/test/launchagent_runner_test.sh
+++ b/scripts/test/launchagent_runner_test.sh
@@ -322,6 +322,34 @@ else
     fi
 fi
 
+# ---- Case 10: launchagent_runner exports HOMEBREW_NO_ASK (issue #20) ----
+# launchd never sources ~/.zshrc, so the runner itself must export
+# HOMEBREW_NO_ASK=1; otherwise a scheduled `make update` hangs forever
+# on Homebrew 6.0's interactive `[y/n]` ask-mode prompt. Assert the
+# child command sees the variable set to 1 in its environment.
+case10_repo="$SANDBOX_BASE/case10/repo"
+case10_home="$SANDBOX_BASE/case10/home"
+mk_fake_repo "$case10_repo"
+mk_fake_home "$case10_repo" "$case10_home"
+
+# Run with HOMEBREW_NO_ASK unset in the parent env so the only way the
+# child can see it is if the runner exported it. `env -u` scrubs any
+# value inherited from the test's own shell.
+HOME="$case10_home" env -u HOMEBREW_NO_ASK \
+    "$case10_repo/scripts/launchagent_runner.sh" \
+    ask-job -- /bin/sh -c 'echo "NO_ASK=[${HOMEBREW_NO_ASK:-UNSET}]"'
+
+log_file="$case10_home/Library/Logs/macos-setup/ask-job.log"
+if [[ ! -f "$log_file" ]]; then
+    fail "case 10: log file not created at $log_file"
+elif ! grep -q "NO_ASK=\[1\]" "$log_file"; then
+    echo "--- log content ---" >&2
+    cat "$log_file" >&2
+    fail "case 10: child command did not see HOMEBREW_NO_ASK=1"
+else
+    pass "case 10: launchagent_runner exports HOMEBREW_NO_ASK=1 to the job"
+fi
+
 # ---- summary ----
 echo
 if [[ $FAIL -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Homebrew 6.0 made ask mode the default for `install`/`upgrade`/`reinstall` (and, via `brew bundle`'s default upgrade, for bundle too), so every such call now blocks on a `Do you want to proceed? [y/n]` prompt. Under the scheduled LaunchAgent path there is no controlling TTY, so `make update` **hangs indefinitely** — the daily/weekly jobs never complete or email a result.

The fix sets `HOMEBREW_NO_ASK=1` in **both** environments where brew runs. These are wired independently and both are needed: **launchd does not source `~/.zshrc`**, so the interactive export alone would never reach the scheduled job.

## Changes

- **`scripts/core_setup.sh`** — grep-guarded `~/.zshrc` append, cloned from the adjacent `HOMEBREW_NO_AUTO_UPDATE` block. Covers interactive shells; idempotent (re-runs skip via the guard).
- **`scripts/launchagent_runner.sh`** — `export HOMEBREW_NO_ASK=1` near the top so every scheduled job inherits it through the one shared entry point. Existing schedules self-heal on the next repo pull — no `make schedule-*` re-run needed.
- **`bootstrap.sh`** — prefix the `mas`/`dasel` install/upgrade lines with `HOMEBREW_NO_ASK=1`. bootstrap runs before `~/.zshrc` gains the export, so it is otherwise still exposed to the prompt.

A single env var covers the whole class (formula/cask upgrade, reinstall, and `brew bundle`) in one lever, so no per-site `--yes` edits are needed.

## Testing

- Added `scripts/test/launchagent_runner_test.sh` **case 10**, which invokes the runner with `HOMEBREW_NO_ASK` scrubbed from the parent env (`env -u`) and asserts the child command sees `HOMEBREW_NO_ASK=1` — directly verifying the scheduled-scope fix.
- Full `launchagent_runner_test.sh` suite passes (13 assertions, cases 1–10).
- Verified the `core_setup.sh` grep-guard idempotency manually: the `~/.zshrc` line is added exactly once and re-runs skip it.

## Decisions

- **bootstrap.sh (optional per the issue): included.** It is the same class of exposed brew call and runs before the `~/.zshrc` export exists, so leaving it out would keep a gap on a fresh machine. Cost is two one-line prefixes.
- No per-site `--yes`/`--no-ask` flags — the env var has strictly broader coverage (it reaches `brew bundle`, which `--yes` does not).

References: #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019o45pawkAVkTAQWjHKEgGR