### PR TITLE
Update stale Homebrew casks in gcp and google-workspace profiles

### DIFF
--- a/profiles/gcp/Install/09-Install.development
+++ b/profiles/gcp/Install/09-Install.development
@@ -1,4 +1,4 @@
 # 09-Install.development for the 'gcp' profile
 
 # Casks
-cask 'google-cloud-sdk'
+cask 'gcloud-cli'

--- a/profiles/google-workspace/Install/18-Install.msoffice
+++ b/profiles/google-workspace/Install/18-Install.msoffice
@@ -3,4 +3,3 @@
 # Casks
 cask 'google-drive'
 cask 'google-chat'
-cask 'google-meet'


### PR DESCRIPTION
## Summary

Two casks in profile `Install/` files no longer resolve against current Homebrew:

- **`google-cloud-sdk` → `gcloud-cli`**: the cask was renamed. Updated in `profiles/gcp/Install/09-Install.development`.
- **`google-meet` removed**: the cask no longer exists. Removed from `profiles/google-workspace/Install/18-Install.msoffice`.

## Testing

- Confirmed via repo-wide grep that these were the only two references to the affected names (no Uninstall/RemoveAndPurge/docs references to sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)