### PR TITLE
Remove google-chat cask from google-workspace profile

### DIFF
--- a/profiles/google-workspace/Install/18-Install.msoffice
+++ b/profiles/google-workspace/Install/18-Install.msoffice
@@ -2,4 +2,3 @@
 
 # Casks
 cask 'google-drive'
-cask 'google-chat'


### PR DESCRIPTION
Removes the `google-chat` cask from the `google-workspace` profile's `18-Install.msoffice` slot, leaving only `google-drive`.

This stops future installs of Google Chat via this profile. It does not uninstall an already-installed copy (no `RemoveAndPurge/` entry was added, per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsHARBSxXxTbjBzjeZfCeZ