### PR TITLE
Forward flags to claude from cr and add debug logging

### DIFF
--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -63,8 +63,27 @@ cr-repo () {
 # INT and TERM are trapped alongside EXIT so that a signal which kills the
 # shell outright (rather than just returning from the function) still
 # tears down the throwaway .git.
+#
+# Arguments are split at the FIRST argument starting with `-`: everything
+# before it forms the session name suffix, and that argument plus all that
+# follow are passed through to `claude` verbatim. So `cr my session
+# --model opus` names the session "my session <repo>" and forwards
+# `--model opus`. With no leading words the suffix falls back to a
+# timestamp, as before.
 cr () {
     local url repo suffix name initdir toplevel
+    local -a claude_args name_words
+
+    while (( $# )); do
+        if [[ "$1" == -* ]]; then
+            # First flag: this and everything after it belongs to claude.
+            claude_args=("$@")
+            break
+        fi
+        name_words+=("$1")
+        shift
+    done
+
     if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         # Inside an existing repo (root or subdir). Move to the repo root
         # and reuse the existing .git -- no throwaway, no cleanup trap.
@@ -90,10 +109,13 @@ cr () {
         trap "rm -rf -- ${(q)initdir}/.git" EXIT INT TERM
         repo="(local)"
     fi
-    suffix="$*"
+
+    suffix="${name_words[*]}"
     if [[ -z "$suffix" ]]; then
         suffix="$(date '+%b%d-%H:%M')"
     fi
     name="${suffix} ${repo}"
-    claude --name "$name" --remote-control
+    claude --name "$name" --remote-control \
+        --debug-file "$HOME/.claude/logs/$name" \
+        "${claude_args[@]}"
 }

--- a/profiles/visual-studio-code/.vscode/settings.json
+++ b/profiles/visual-studio-code/.vscode/settings.json
@@ -20,5 +20,8 @@
     "aws.cloudformation.telemetry.enabled": false,
     "[json]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    }
+    },
+    "[markdown]": { "editor.colorDecorators": false },
+    "[plaintext]": { "editor.colorDecorators": false },
+    "[git-commit]": { "editor.colorDecorators": false }
 }


### PR DESCRIPTION
## Summary

Two unrelated-but-small config changes that were sitting dirty in the working tree.

### `profiles/claude-code-aliases/aliases.zsh`

`cr` consumed **all** of its arguments as the session-name suffix, so there was no way to pass a `claude` flag through it. The argument list is now split at the first argument starting with `-`:

- leading words → session name suffix (unchanged behavior when no flags are given)
- that argument and everything after it → forwarded to `claude` verbatim

```zsh
cr my session --model opus   # name: "my session macos-setup", forwards --model opus
cr                           # name: "Jul26-21:22 macos-setup" (timestamp fallback)
```

Also adds `--debug-file "$HOME/.claude/logs/$name"` so each session leaves a debug log named after itself.

### `profiles/visual-studio-code/.vscode/settings.json`

Disables VS Code's inline color decorators for `markdown`, `plaintext`, and `git-commit` buffers — hex-like strings in prose were being decorated as color swatches.

## Notes / open questions

- `$name` contains a space and a colon (e.g. `Jul26-21:22 macos-setup`), so the debug-file path does too. I have **not** verified that `claude --debug-file` creates `~/.claude/logs/` if it is absent, or how it handles those characters. If it doesn't, this wants an `mkdir -p` and a sanitized filename — happy to follow up.
- The `settings.json` file still has no trailing newline; that is pre-existing and left alone.

## Test plan

- [ ] `cr` with no args in a repo → timestamped session name, no forwarded flags
- [ ] `cr some name` → session named `some name <repo>`
- [ ] `cr some name --model opus` → same name, `--model opus` reaches claude
- [ ] `cr` outside a repo → throwaway `.git` created and removed on exit
- [ ] Confirm `~/.claude/logs/` behavior per the note above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC61kvyMGenNdfrXFKkNTU
