### PR TITLE
Point cr at a Claude-specific global git config

### DIFF
--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -75,11 +75,19 @@ cr () {
     local -a claude_args name_words
 
     # Point git at a Claude-specific global config (bot identity, etc.) for
-    # this session, unless the caller already set one. Like the `cd` below,
-    # the export persists in the calling shell after `cr` returns.
+    # the duration of this call, unless the caller already set one.
+    #
+    # `local -x` is what confines it: a zsh `local` is dynamically scoped, so
+    # the value is visible to `claude` and to every git command this function
+    # runs, and is restored when `cr` returns -- on EVERY return path,
+    # including a Ctrl-C out of `claude`. Unlike the `cd` to the repo root,
+    # this deliberately does NOT persist in the calling shell; a plain
+    # `export` would silently repoint git for the rest of the session.
+    # The declaration lives inside the `if` so an outer value is never
+    # shadowed by an empty local.
     if [[ -z "${GIT_CONFIG_GLOBAL:-}" ]]; then
         cfg="$HOME/.gitconfig-claude"
-        [[ -r "$cfg" ]] && export GIT_CONFIG_GLOBAL="$cfg"
+        [[ -r "$cfg" ]] && local -x GIT_CONFIG_GLOBAL="$cfg"
     fi
 
     while (( $# )); do

--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -71,8 +71,16 @@ cr-repo () {
 # `--model opus`. With no leading words the suffix falls back to a
 # timestamp, as before.
 cr () {
-    local url repo suffix name initdir toplevel
+    local url repo suffix name initdir toplevel cfg
     local -a claude_args name_words
+
+    # Point git at a Claude-specific global config (bot identity, etc.) for
+    # this session, unless the caller already set one. Like the `cd` below,
+    # the export persists in the calling shell after `cr` returns.
+    if [[ -z "${GIT_CONFIG_GLOBAL:-}" ]]; then
+        cfg="$HOME/.gitconfig-claude"
+        [[ -r "$cfg" ]] && export GIT_CONFIG_GLOBAL="$cfg"
+    fi
 
     while (( $# )); do
         if [[ "$1" == -* ]]; then


### PR DESCRIPTION
## What

`cr` (in `profiles/claude-code-aliases/aliases.zsh`) now points git at
`~/.gitconfig-claude` for the duration of the call, so the Claude session it
launches uses a git identity/config separate from the user's own.

Guarded twice:

- only when the caller has not already set `GIT_CONFIG_GLOBAL` (an explicit
  caller value wins);
- only when `~/.gitconfig-claude` is readable — a missing file is a silent
  no-op, so hosts that opt into this profile without creating the file behave
  exactly as before.

## Scoping

The variable is set with `local -x`, not `export`. A plain `export` inside a
zsh function persists in the calling shell, which would silently repoint git
for the rest of that terminal session — not just for the Claude session `cr`
launches. `local -x` is dynamically scoped: the value reaches `claude` and the
git commands `cr` itself runs, and the caller's environment is restored on
every return path, including a Ctrl-C out of `claude`.

This is deliberately different from the `cd` to the repo root, which does
persist and is documented as accepted behavior.

The declaration sits inside the `-z` branch so a caller-supplied value is never
shadowed by an empty local.

## Testing

`zsh -n profiles/claude-code-aliases/aliases.zsh` passes.

The scoping was exercised in a standalone zsh harness rather than assumed, over
all four paths:

| Case | In function | Child process | After return |
| --- | --- | --- | --- |
| File present, caller unset | set | inherits | unset again |
| Caller already set | caller's value | caller's value | caller's value |
| `~/.gitconfig-claude` missing | unset | unset | unset |
| Early non-zero return (Ctrl-C stand-in) | — | — | unset |

No other file in the repo references `GIT_CONFIG_GLOBAL` or
`~/.gitconfig-claude`.
