### PR TITLE
Add claude-vm wrapper resolved from the plugin DB

### DIFF
--- a/profiles/claude-code-aliases/05-Install.tools
+++ b/profiles/claude-code-aliases/05-Install.tools
@@ -1,0 +1,7 @@
+# 05-Install.tools for the 'claude-code-aliases' profile
+
+# Homebrew formulae
+# jq parses ~/.claude/plugins/installed_plugins.json in the
+# claude-plugin-path helper this profile's aliases.zsh defines, so the
+# profile declares it rather than relying on another profile's install.
+brew 'jq'

--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -135,3 +135,29 @@ cr () {
         --debug-file "$HOME/.claude/logs/$name" \
         "${claude_args[@]}"
 }
+# Resolve an installed Claude Code plugin's root from the plugin DB.
+# installed_plugins.json stores installPath directly, so this tracks
+# plugin updates automatically. The per-plugin value is an array (one
+# entry per scope) -- prefer user scope, fall back to first.
+claude-plugin-path() {
+  local key=$1 db=${CLAUDE_PLUGINS_DB:-$HOME/.claude/plugins/installed_plugins.json}
+  [[ -r $db ]] || return 1
+  jq -er --arg k "$key" '
+    (.plugins[$k] // []) as $e
+    | (($e | map(select(.scope == "user"))) + $e)[0].installPath // empty
+  ' "$db" 2>/dev/null
+}
+
+claude-vm() {
+  local root exe
+  root=$(claude-plugin-path 'claude-vm@thevoskamps') || {
+    print -ru2 -- "claude-vm: plugin claude-vm@thevoskamps is not installed"
+    return 127
+  }
+  exe=$root/bin/claude-vm
+  [[ -x $exe ]] || {
+    print -ru2 -- "claude-vm: $exe is missing or not executable"
+    return 127
+  }
+  "$exe" "$@"
+}


### PR DESCRIPTION
Adds two shell functions to the `claude-code-aliases` profile:

- `claude-plugin-path <key>` — reads `installPath` for a plugin out of
  `~/.claude/plugins/installed_plugins.json` (preferring the `user`-scope entry,
  falling back to the first). Because the DB is the source of truth, the path
  follows plugin updates instead of going stale like a hardcoded one would.
  `CLAUDE_PLUGINS_DB` overrides the DB location.
- `claude-vm` — dispatches to `<plugin root>/bin/claude-vm` via that helper, and
  exits 127 with a message when either the plugin or the binary is missing,
  rather than failing silently.

The helper depends on `jq`, so the profile gains its own
`Install/05-Install.tools` declaring it rather than relying on another profile
being opted into on the same host.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPYE5Sj8VBiucHidg7hAXc
