### PR TITLE
Harden Makefile bash invocations and finish the update-path mise cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,12 +487,17 @@ Makefile recipe names bash as `$(BASH_BIN)`, the
 absolute `/bin/bash` that `SHELL` is also set from,
 rather than a PATH-resolved bare `bash` that would
 die with `/bin/bash: /opt/homebrew/bin/bash: No such
-file or directory` once that formula was gone. The
-two scripts that re-invoke bash themselves
-(`shell_setup.sh`, `claude_repo_setup.sh`) name
-`/bin/bash` for the same reason.
+file or directory` once that formula was gone. Every
+script that re-invokes bash itself names `/bin/bash`
+for the same reason: `shell_setup.sh` and
+`claude_repo_setup.sh`, which run helper scripts, and
+`ensure_mise_zshrc_lines.sh`, whose reachability probe
+runs `/bin/bash -lc`.
 `scripts/test/absolute_bash_test.sh` fails if either
-invariant is dropped.
+invariant is dropped — it pins the
+`HOMEBREW_NO_AUTOREMOVE` export and scans the Makefile,
+`shell_setup.sh`, and `claude_repo_setup.sh` for a bare
+`bash`.
 
 A second Homebrew 6.0 quirk is **interactive ask-mode**
 (issue #20): 6.0 made a `Do you want to proceed? [y/n]`
@@ -717,7 +722,12 @@ asdf/direnv init lines this repo once wrote, and
 `scripts/ensure_mise_zshrc_lines.sh` adds
 `export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"`
 plus `eval "$(mise activate zsh)"` (the activation line
-only when mise is reachable). `make shell`
+only when mise is reachable — this shell's `PATH`
+first, then a fallback to the `/bin/bash -lc`
+login-shell probe the `MISE_REACHABLE` Makefile macro
+is, so the gate that removes asdf and the gate that
+writes the activation line cannot disagree within one
+run). `make shell`
 (`scripts/shell_setup.sh`) calls both, in that order, and
 so does `make update` — which never runs
 `shell_setup.sh`, so before issue #38 it stripped without

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,6 +476,24 @@ SUDO=<stub>` reaches the runner for all three.
 fails if a bare `brew`, `mas`, or `sudo` call is
 reintroduced into the runner. See `docs/INSTALL.md`.
 
+Two further invariants stop a removal run from
+breaking its own later steps (issue #37).
+`remove_runner.sh` exports `HOMEBREW_NO_AUTOREMOVE=1`,
+so `brew uninstall`'s automatic `brew autoremove`
+never cascades into a shared dependency — that
+cascade is how uninstalling `asdf` once removed
+Homebrew's `bash` formula mid-run. And every
+Makefile recipe names bash as `$(BASH_BIN)`, the
+absolute `/bin/bash` that `SHELL` is also set from,
+rather than a PATH-resolved bare `bash` that would
+die with `/bin/bash: /opt/homebrew/bin/bash: No such
+file or directory` once that formula was gone. The
+two scripts that re-invoke bash themselves
+(`shell_setup.sh`, `claude_repo_setup.sh`) name
+`/bin/bash` for the same reason.
+`scripts/test/absolute_bash_test.sh` fails if either
+invariant is dropped.
+
 A second Homebrew 6.0 quirk is **interactive ask-mode**
 (issue #20): 6.0 made a `Do you want to proceed? [y/n]`
 prompt the default for `install`/`upgrade`/`reinstall`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -710,26 +710,36 @@ tools. Only the binaries go — `~/.asdf/`,
 `~/.tool-versions`, `~/.config/direnv/lib/use_asdf.sh`
 and every repo's `.envrc` / `.tool-versions` survive, and
 `make asdf-to-mise` warns about each rather than deleting
-it. `scripts/strip_asdf_zshrc_lines.sh` removes the
-asdf/direnv `~/.zshrc` init lines this repo once wrote,
-and `make shell` (`scripts/shell_setup.sh`) calls it
-before adding
+it. The `~/.zshrc` work is a PAIR of scripts, so both
+cutover paths do identical work:
+`scripts/strip_asdf_zshrc_lines.sh` removes the
+asdf/direnv init lines this repo once wrote, and
+`scripts/ensure_mise_zshrc_lines.sh` adds
 `export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"`
-plus `eval "$(mise activate zsh)"`;
+plus `eval "$(mise activate zsh)"` (the activation line
+only when mise is reachable). `make shell`
+(`scripts/shell_setup.sh`) calls both, in that order, and
+so does `make update` — which never runs
+`shell_setup.sh`, so before issue #38 it stripped without
+adding and left the host with no version manager wired
+into the interactive shell.
 `scripts/launchagent_runner.sh` puts the same shims
 directory on `PATH` itself, because launchd never sources
 `~/.zshrc`.
 
 The cutover breaks into distinct pieces -- install mise,
-uninstall asdf + direnv, strip the `~/.zshrc` lines --
-each owned by a different mechanism. `make install` and
+uninstall asdf + direnv, strip the old `~/.zshrc` lines,
+add the mise `~/.zshrc` lines -- each owned by a
+different mechanism. `make install` and
 `make update` each do all of them: `install` runs the
 slot-04 RemoveAndPurge inline (a deliberate one-slot
 exception to "install does not run the removal loops")
-and reaches the strip via `03-Install.shell`, while
+and reaches both `~/.zshrc` rewrites via
+`03-Install.shell`, while
 `update` applies the slot-04 `Install` tiers itself
 before the removal loops and calls
-`strip_asdf_zshrc_lines.sh` directly because it never
+`strip_asdf_zshrc_lines.sh` and then
+`ensure_mise_zshrc_lines.sh` directly because it never
 runs `shell_setup.sh`. `update` needs that explicit
 install step because `brew upgrade` upgrades an
 installed formula but never installs an absent one, so a
@@ -742,7 +752,8 @@ rather than left to the surrounding `set -e`. If mise is
 still unreachable after the install step, `update` skips
 slot 04's `Uninstall` and `RemoveAndPurge` (via the
 `REMOVE_SKIP_BASENAMES` Makefile variable, which the
-batch removal loops honor) and skips the strip, while
+batch removal loops honor) and skips both `~/.zshrc`
+rewrites, while
 `install` skips its inline slot-04 `RemoveAndPurge`;
 both warn and exit non-zero, and every other removal
 slot still applies. `scripts/test/install_cutover_guard_test.sh`
@@ -1190,6 +1201,7 @@ former in-repo `logs/` directory. This is macOS-native
 | `versions_setup.sh` | Drives mise for the `versions-*` targets and slot 04 |
 | `asdf_to_mise.sh` | One-shot additive asdf+direnv -> mise repo migration |
 | `strip_asdf_zshrc_lines.sh` | Strips the ~/.zshrc lines the cutover orphans |
+| `ensure_mise_zshrc_lines.sh` | Adds the mise ~/.zshrc shims/activate lines |
 | `vscode_extensions.sh` | Installs VS Code extensions |
 | `vscode_setup.sh` | Symlinks VS Code `settings.json` (single-winner) |
 | `hammerspoon_setup.sh` | Symlinks HS config; robust reload (IPC + relaunch) |

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,23 @@
 #   - 06-Install.messaging       : sets up msmtp configuration
 #   - 09-Install.development     : sets up VSCode extensions and configuration
 
-SHELL := /bin/bash
+# The bash EVERY recipe uses -- both as make's own recipe shell and as the
+# interpreter every `$(BASH_BIN) scripts/foo.sh` invocation names (issue #37).
+# It is an ABSOLUTE path on purpose: a bare `bash` is resolved through PATH,
+# and on a host whose PATH puts /opt/homebrew/bin first, a removal that takes
+# Homebrew's bash formula out mid-run -- directly, or via the `brew autoremove`
+# that `brew uninstall` triggers -- makes every LATER recipe line die with
+# `/bin/bash: /opt/homebrew/bin/bash: No such file or directory`. That is not
+# hypothetical: it happened during the asdf -> mise cutover and cost the
+# `update` target its ~/.zshrc strip, leaving the host with dead direnv/asdf
+# init lines erroring on every shell startup. /bin/bash ships with macOS and
+# no Homebrew operation can remove it.
+#
+# /bin/bash is bash 3.2. Every script in scripts/ is already written to 3.2
+# (see the mapfile note in scripts/test/hammerspoon_reload_test.sh), so
+# naming it here changes no script's behavior.
+BASH_BIN := /bin/bash
+SHELL := $(BASH_BIN)
 START_DIR ?= $(CURDIR)
 .ONESHELL:
 .NOTPARALLEL:
@@ -37,7 +53,7 @@ COMPUTER_NAME_LOWER := $(shell scutil --get LocalHostName 2>/dev/null | tr '[:up
 # the default is $${XDG_CONFIG_HOME:-$$HOME/.config}/macos-setup.
 # Delegated to a script (rather than inlined) for the same reason as
 # PROFILES below: keep host-path logic in one place (config_common.sh).
-HOST_DIR := $(shell bash scripts/host_tier_dir.sh 2>/dev/null)
+HOST_DIR := $(shell $(BASH_BIN) scripts/host_tier_dir.sh 2>/dev/null)
 COMPUTER_SPECIFIC_DIR   := $(HOST_DIR)/$(INSTALL_DIR)
 COMPUTER_UNINSTALL_DIR  := $(HOST_DIR)/$(UNINSTALL_DIR)
 COMPUTER_PURGE_DIR      := $(HOST_DIR)/$(PURGE_DIR)
@@ -50,7 +66,7 @@ COMPUTER_PURGE_DIR      := $(HOST_DIR)/$(PURGE_DIR)
 # Parsing is delegated to scripts/list_profiles.sh (which reuses
 # get_profiles in config_common.sh, querying config.toml via dasel)
 # rather than inlined here.
-PROFILES := $(shell bash scripts/list_profiles.sh 2>/dev/null)
+PROFILES := $(shell $(BASH_BIN) scripts/list_profiles.sh 2>/dev/null)
 
 INSTALL_FILTER := scripts/install_filter.sh
 REMOVE_RUNNER  := scripts/remove_runner.sh
@@ -117,12 +133,12 @@ VERSIONS_SETUP := scripts/versions_setup.sh
 # It is a macro, not two hand-written `command -v` calls, so the two
 # paths cannot drift and neither can lose the guard silently.
 #
-# `bash -lc` because a mise installed moments earlier in the same run
+# `$(BASH_BIN) -lc` because a mise installed moments earlier in the same run
 # lands on a login shell's PATH, not necessarily on make's. `$${MISE:-mise}`
 # honors the same override scripts/mise_common.sh reads, which is also
 # what lets scripts/test/install_cutover_guard_test.sh point it at an
 # absent binary.
-MISE_REACHABLE = bash -lc 'command -v "$${MISE:-mise}" >/dev/null 2>&1'
+MISE_REACHABLE = $(BASH_BIN) -lc 'command -v "$${MISE:-mise}" >/dev/null 2>&1'
 
 # Helpers
 CANON      = $(subst -,_,$(subst .,_,$(1)))
@@ -190,7 +206,7 @@ endef
 define RUN_GLOBAL_UNINSTALL
 	@set -euo pipefail; \
 	if [ -f "$(UNINSTALL_DIR)/$(1)" ]; then \
-		bash $(REMOVE_RUNNER) "$(UNINSTALL_DIR)/$(1)" --mode=uninstall --banner="==> Applying global Uninstall: $(UNINSTALL_DIR)/$(1)" $(2); \
+		$(BASH_BIN) $(REMOVE_RUNNER) "$(UNINSTALL_DIR)/$(1)" --mode=uninstall --banner="==> Applying global Uninstall: $(UNINSTALL_DIR)/$(1)" $(2); \
 	fi
 endef
 
@@ -199,7 +215,7 @@ define RUN_PROFILE_UNINSTALL
 	for prof in $(PROFILES); do \
 		pf="profiles/$$prof/$(UNINSTALL_DIR)/$(1)"; \
 		if [ -f "$$pf" ]; then \
-			bash $(REMOVE_RUNNER) "$$pf" --mode=uninstall --banner="==> Applying profile Uninstall: $$pf" $(2); \
+			$(BASH_BIN) $(REMOVE_RUNNER) "$$pf" --mode=uninstall --banner="==> Applying profile Uninstall: $$pf" $(2); \
 		fi; \
 	done
 endef
@@ -207,7 +223,7 @@ endef
 define RUN_COMPUTER_UNINSTALL
 	@set -euo pipefail; \
 	if [ -f "$(COMPUTER_UNINSTALL_DIR)/$(1)" ]; then \
-		bash $(REMOVE_RUNNER) "$(COMPUTER_UNINSTALL_DIR)/$(1)" --mode=uninstall --banner="==> Applying computer-specific Uninstall: $(COMPUTER_UNINSTALL_DIR)/$(1)" $(2); \
+		$(BASH_BIN) $(REMOVE_RUNNER) "$(COMPUTER_UNINSTALL_DIR)/$(1)" --mode=uninstall --banner="==> Applying computer-specific Uninstall: $(COMPUTER_UNINSTALL_DIR)/$(1)" $(2); \
 	fi
 endef
 
@@ -218,7 +234,7 @@ endef
 define RUN_GLOBAL_PURGE
 	@set -euo pipefail; \
 	if [ -f "$(PURGE_DIR)/$(1)" ]; then \
-		bash $(REMOVE_RUNNER) "$(PURGE_DIR)/$(1)" --mode=purge --banner="==> Applying global RemoveAndPurge: $(PURGE_DIR)/$(1)" $(2); \
+		$(BASH_BIN) $(REMOVE_RUNNER) "$(PURGE_DIR)/$(1)" --mode=purge --banner="==> Applying global RemoveAndPurge: $(PURGE_DIR)/$(1)" $(2); \
 	fi
 endef
 
@@ -227,7 +243,7 @@ define RUN_PROFILE_PURGE
 	for prof in $(PROFILES); do \
 		pf="profiles/$$prof/$(PURGE_DIR)/$(1)"; \
 		if [ -f "$$pf" ]; then \
-			bash $(REMOVE_RUNNER) "$$pf" --mode=purge --banner="==> Applying profile RemoveAndPurge: $$pf" $(2); \
+			$(BASH_BIN) $(REMOVE_RUNNER) "$$pf" --mode=purge --banner="==> Applying profile RemoveAndPurge: $$pf" $(2); \
 		fi; \
 	done
 endef
@@ -235,7 +251,7 @@ endef
 define RUN_COMPUTER_PURGE
 	@set -euo pipefail; \
 	if [ -f "$(COMPUTER_PURGE_DIR)/$(1)" ]; then \
-		bash $(REMOVE_RUNNER) "$(COMPUTER_PURGE_DIR)/$(1)" --mode=purge --banner="==> Applying computer-specific RemoveAndPurge: $(COMPUTER_PURGE_DIR)/$(1)" $(2); \
+		$(BASH_BIN) $(REMOVE_RUNNER) "$(COMPUTER_PURGE_DIR)/$(1)" --mode=purge --banner="==> Applying computer-specific RemoveAndPurge: $(COMPUTER_PURGE_DIR)/$(1)" $(2); \
 	fi
 endef
 
@@ -258,7 +274,7 @@ finder_defaults: ## Set Finder to List view & show hidden files; purge .DS_Store
 .PHONY: shell_setup
 shell_setup: ## Configure zsh, Oh My Zsh, theme, plugins, aliases (idempotent)
 	@set -euo pipefail
-	bash scripts/shell_setup.sh
+	$(BASH_BIN) scripts/shell_setup.sh
 
 # --- Per-Install targets (auto-generated, excluding special-cased ones) ---
 CORE_INSTALL  := 00-Install.core
@@ -289,35 +305,35 @@ $(foreach b,$(INSTALL_NO_SPECIAL),$(eval $(call GEN_INSTALL_TARGET,$(b))))
 # Special cases
 00_Install_core: ## Apply $(INSTALL_DIR)/$(CORE_INSTALL) and setup computer names
 	$(call APPLY_INSTALL_TIERS,$(CORE_INSTALL))
-	@bash -lc 'if [ -x "scripts/core_setup.sh" ]; then scripts/core_setup.sh; else echo "[core] scripts/core_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/core_setup.sh" ]; then scripts/core_setup.sh; else echo "[core] scripts/core_setup.sh not found or not executable"; fi'
 
 02_Install_ui: ## Apply $(INSTALL_DIR)/$(UI_INSTALL) and setup Hammerspoon
 	$(call APPLY_INSTALL_TIERS,$(UI_INSTALL))
-	@bash -lc 'if [ -x "scripts/hammerspoon_setup.sh" ]; then scripts/hammerspoon_setup.sh; else echo "[hammerspoon] scripts/hammerspoon_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/hammerspoon_setup.sh" ]; then scripts/hammerspoon_setup.sh; else echo "[hammerspoon] scripts/hammerspoon_setup.sh not found or not executable"; fi'
 
 03_Install_shell: ## Apply $(INSTALL_DIR)/$(SHELL_INSTALL) and run shell setup
 	$(call APPLY_INSTALL_TIERS,$(SHELL_INSTALL))
-	@bash -lc 'if [ -x "scripts/shell_setup.sh" ]; then scripts/shell_setup.sh; else echo "[shell] scripts/shell_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/shell_setup.sh" ]; then scripts/shell_setup.sh; else echo "[shell] scripts/shell_setup.sh not found or not executable"; fi'
 
 06_Install_messaging: ## Apply $(INSTALL_DIR)/$(MSG_INSTALL) and setup msmtp config
 	$(call APPLY_INSTALL_TIERS,$(MSG_INSTALL))
-	@bash -lc 'if [ -x "scripts/msmtp_setup.sh" ]; then scripts/msmtp_setup.sh; else echo "[messaging] scripts/msmtp_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/msmtp_setup.sh" ]; then scripts/msmtp_setup.sh; else echo "[messaging] scripts/msmtp_setup.sh not found or not executable"; fi'
 
 09_Install_development: ## Apply $(INSTALL_DIR)/$(DEV_INSTALL), install VSCode extensions, and setup VSCode config
 	$(call APPLY_INSTALL_TIERS,$(DEV_INSTALL))
-	@bash -lc 'if [ -x "scripts/vscode_extensions.sh" ]; then scripts/vscode_extensions.sh code; else echo "[development] scripts/vscode_extensions.sh not found or not executable"; fi' || true
-	@bash -lc 'if [ -x "scripts/vscode_setup.sh" ]; then scripts/vscode_setup.sh; else echo "[development] scripts/vscode_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/vscode_extensions.sh" ]; then scripts/vscode_extensions.sh code; else echo "[development] scripts/vscode_extensions.sh not found or not executable"; fi' || true
+	@$(BASH_BIN) -lc 'if [ -x "scripts/vscode_setup.sh" ]; then scripts/vscode_setup.sh; else echo "[development] scripts/vscode_setup.sh not found or not executable"; fi'
 
 11_Install_aws: ## Apply $(INSTALL_DIR)/$(AWS_INSTALL) and setup CDK config
 	$(call APPLY_INSTALL_TIERS,$(AWS_INSTALL))
-	@bash -lc 'if [ -x "scripts/cdk_setup.sh" ]; then scripts/cdk_setup.sh; else echo "[aws] scripts/cdk_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/cdk_setup.sh" ]; then scripts/cdk_setup.sh; else echo "[aws] scripts/cdk_setup.sh not found or not executable"; fi'
 
 17_Install_ai: ## Apply $(INSTALL_DIR)/$(AI_INSTALL), install Cursor extensions, disable auto-updates, and setup Claude config
 	$(call APPLY_INSTALL_TIERS,$(AI_INSTALL))
-	@bash -lc 'if [ -x "scripts/vscode_extensions.sh" ]; then scripts/vscode_extensions.sh cursor; else echo "[ai] scripts/vscode_extensions.sh not found or not executable"; fi' || true
+	@$(BASH_BIN) -lc 'if [ -x "scripts/vscode_extensions.sh" ]; then scripts/vscode_extensions.sh cursor; else echo "[ai] scripts/vscode_extensions.sh not found or not executable"; fi' || true
 	@claude config set -g autoUpdates false >/dev/null 2>&1 || true
-	@bash -lc 'if [ -x "scripts/claude_disable_autoupdater.sh" ]; then scripts/claude_disable_autoupdater.sh; else echo "[ai] scripts/claude_disable_autoupdater.sh not found or not executable"; fi'
-	@bash -lc 'if [ -x "scripts/claude_repo_setup.sh" ]; then scripts/claude_repo_setup.sh install; else echo "[ai] scripts/claude_repo_setup.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/claude_disable_autoupdater.sh" ]; then scripts/claude_disable_autoupdater.sh; else echo "[ai] scripts/claude_disable_autoupdater.sh not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "scripts/claude_repo_setup.sh" ]; then scripts/claude_repo_setup.sh install; else echo "[ai] scripts/claude_repo_setup.sh not found or not executable"; fi'
 
 
 # --- Per-Uninstall targets (auto-generated for every Uninstall/<NN-Uninstall.suffix>) ---
@@ -369,19 +385,19 @@ $(foreach p,$(PURGE_BASENAMES),$(eval $(call GEN_PURGE_TARGET,$(p))))
 .PHONY: claude-install claude-update claude-outdated claude-plugins-install claude-plugins-update
 
 claude-install: ## Install or migrate ~/.claude/ from the global Claude config repo
-	@bash scripts/claude_repo_setup.sh install
+	@$(BASH_BIN) scripts/claude_repo_setup.sh install
 
 claude-update: ## Update ~/.claude/ (errors if not yet installed via claude-install)
-	@bash scripts/claude_repo_setup.sh update
+	@$(BASH_BIN) scripts/claude_repo_setup.sh update
 
 claude-outdated: ## Show pending pulls/pushes and dirty files in ~/.claude/ (read-only)
-	@bash scripts/claude_repo_setup.sh outdated
+	@$(BASH_BIN) scripts/claude_repo_setup.sh outdated
 
 claude-plugins-install: ## Sync Claude plugins via the clone's own ~/.claude/plugins.sh --install
-	@bash scripts/claude_repo_setup.sh plugins-install
+	@$(BASH_BIN) scripts/claude_repo_setup.sh plugins-install
 
 claude-plugins-update: ## Update Claude plugins via the clone's own ~/.claude/plugins.sh --update
-	@bash scripts/claude_repo_setup.sh plugins-update
+	@$(BASH_BIN) scripts/claude_repo_setup.sh plugins-update
 
 
 # --- Host-tier seeding ---
@@ -391,7 +407,7 @@ claude-plugins-update: ## Update Claude plugins via the clone's own ~/.claude/pl
 # overwritten. This target exposes the same step standalone.
 .PHONY: seed-host-tier
 seed-host-tier: ## Seed the external host tier from the template if absent (no-op if it already exists)
-	@bash scripts/seed_host_tier.sh
+	@$(BASH_BIN) scripts/seed_host_tier.sh
 
 # --- dasel reachability gate (issue #4) ---
 # Every config.toml read in this repo invokes `dasel` by BARE NAME (the
@@ -422,7 +438,7 @@ seed-host-tier: ## Seed the external host tier from the template if absent (no-o
 # `Error: dasel not in PATH.` the sole output on a no-dasel run.
 .PHONY: require-dasel
 require-dasel:
-	@bash scripts/require_dasel_on_path.sh
+	@$(BASH_BIN) scripts/require_dasel_on_path.sh
 
 # --- Batch targets ---
 #
@@ -496,16 +512,16 @@ install: require-dasel ## Apply all Install files in numeric order (filtered aga
 				vmp="$(VM_PURGE)"; \
 				if $(MISE_REACHABLE); then \
 					if [ -f "$(PURGE_DIR)/$$vmp" ]; then \
-						bash $(REMOVE_RUNNER) "$(PURGE_DIR)/$$vmp" --mode=purge --banner="==> Applying global RemoveAndPurge: $(PURGE_DIR)/$$vmp" || failed="$$failed $(PURGE_DIR)/$$vmp"; \
+						$(BASH_BIN) $(REMOVE_RUNNER) "$(PURGE_DIR)/$$vmp" --mode=purge --banner="==> Applying global RemoveAndPurge: $(PURGE_DIR)/$$vmp" || failed="$$failed $(PURGE_DIR)/$$vmp"; \
 					fi; \
 					for prof in $(PROFILES); do \
 						vpf="profiles/$$prof/$(PURGE_DIR)/$$vmp"; \
 						if [ -f "$$vpf" ]; then \
-							bash $(REMOVE_RUNNER) "$$vpf" --mode=purge --banner="==> Applying profile RemoveAndPurge: $$vpf" || failed="$$failed $$vpf"; \
+							$(BASH_BIN) $(REMOVE_RUNNER) "$$vpf" --mode=purge --banner="==> Applying profile RemoveAndPurge: $$vpf" || failed="$$failed $$vpf"; \
 						fi; \
 					done; \
 					if [ -f "$(COMPUTER_PURGE_DIR)/$$vmp" ]; then \
-						bash $(REMOVE_RUNNER) "$(COMPUTER_PURGE_DIR)/$$vmp" --mode=purge --banner="==> Applying computer-specific RemoveAndPurge: $(COMPUTER_PURGE_DIR)/$$vmp" || failed="$$failed $(COMPUTER_PURGE_DIR)/$$vmp"; \
+						$(BASH_BIN) $(REMOVE_RUNNER) "$(COMPUTER_PURGE_DIR)/$$vmp" --mode=purge --banner="==> Applying computer-specific RemoveAndPurge: $(COMPUTER_PURGE_DIR)/$$vmp" || failed="$$failed $(COMPUTER_PURGE_DIR)/$$vmp"; \
 					fi; \
 				else \
 					vm_purge_skipped="$$vmp"; \
@@ -564,16 +580,16 @@ _uninstall_loop:
 		ubase="$$(basename "$$u")"; \
 		case " $(REMOVE_SKIP_BASENAMES) " in *" $$ubase "*) continue;; esac; \
 		if [ -f "$$u" ]; then \
-			bash $(REMOVE_RUNNER) "$$u" --mode=uninstall --banner="==> Applying global Uninstall: $$u" $(UNINSTALL_DRY_RUN); \
+			$(BASH_BIN) $(REMOVE_RUNNER) "$$u" --mode=uninstall --banner="==> Applying global Uninstall: $$u" $(UNINSTALL_DRY_RUN); \
 		fi; \
 		for prof in $(PROFILES); do \
 			pf="profiles/$$prof/$(UNINSTALL_DIR)/$$ubase"; \
 			if [ -f "$$pf" ]; then \
-				bash $(REMOVE_RUNNER) "$$pf" --mode=uninstall --banner="==> Applying profile Uninstall: $$pf" $(UNINSTALL_DRY_RUN); \
+				$(BASH_BIN) $(REMOVE_RUNNER) "$$pf" --mode=uninstall --banner="==> Applying profile Uninstall: $$pf" $(UNINSTALL_DRY_RUN); \
 			fi; \
 		done; \
 		if [ -f "$(COMPUTER_UNINSTALL_DIR)/$$ubase" ]; then \
-			bash $(REMOVE_RUNNER) "$(COMPUTER_UNINSTALL_DIR)/$$ubase" --mode=uninstall --banner="==> Applying computer-specific Uninstall: $(COMPUTER_UNINSTALL_DIR)/$$ubase" $(UNINSTALL_DRY_RUN); \
+			$(BASH_BIN) $(REMOVE_RUNNER) "$(COMPUTER_UNINSTALL_DIR)/$$ubase" --mode=uninstall --banner="==> Applying computer-specific Uninstall: $(COMPUTER_UNINSTALL_DIR)/$$ubase" $(UNINSTALL_DRY_RUN); \
 		fi; \
 	done; \
 	if [ $$any -eq 0 ]; then echo "No Uninstall files found in $(UNINSTALL_DIR)/"; fi; \
@@ -600,16 +616,16 @@ _remove_and_purge_loop:
 		ubase="$$(basename "$$u")"; \
 		case " $(REMOVE_SKIP_BASENAMES) " in *" $$ubase "*) continue;; esac; \
 		if [ -f "$$u" ]; then \
-			bash $(REMOVE_RUNNER) "$$u" --mode=purge --banner="==> Applying global RemoveAndPurge: $$u" $(PURGE_DRY_RUN); \
+			$(BASH_BIN) $(REMOVE_RUNNER) "$$u" --mode=purge --banner="==> Applying global RemoveAndPurge: $$u" $(PURGE_DRY_RUN); \
 		fi; \
 		for prof in $(PROFILES); do \
 			pf="profiles/$$prof/$(PURGE_DIR)/$$ubase"; \
 			if [ -f "$$pf" ]; then \
-				bash $(REMOVE_RUNNER) "$$pf" --mode=purge --banner="==> Applying profile RemoveAndPurge: $$pf" $(PURGE_DRY_RUN); \
+				$(BASH_BIN) $(REMOVE_RUNNER) "$$pf" --mode=purge --banner="==> Applying profile RemoveAndPurge: $$pf" $(PURGE_DRY_RUN); \
 			fi; \
 		done; \
 		if [ -f "$(COMPUTER_PURGE_DIR)/$$ubase" ]; then \
-			bash $(REMOVE_RUNNER) "$(COMPUTER_PURGE_DIR)/$$ubase" --mode=purge --banner="==> Applying computer-specific RemoveAndPurge: $(COMPUTER_PURGE_DIR)/$$ubase" $(PURGE_DRY_RUN); \
+			$(BASH_BIN) $(REMOVE_RUNNER) "$(COMPUTER_PURGE_DIR)/$$ubase" --mode=purge --banner="==> Applying computer-specific RemoveAndPurge: $(COMPUTER_PURGE_DIR)/$$ubase" $(PURGE_DRY_RUN); \
 		fi; \
 	done; \
 	if [ $$any -eq 0 ]; then echo "No RemoveAndPurge files found in $(PURGE_DIR)/"; fi; \
@@ -676,12 +692,12 @@ update: require-dasel ## Update Homebrew, upgrade formulae/casks/MAS/managed too
 	echo "==> Pruning unused mise-managed versions..."; \
 	$(MAKE) -s versions-cleanup || FAIL=1; \
 	echo "==> Updating ~/.claude/ from the global Claude config repo..."; \
-	if [ -x "scripts/claude_repo_setup.sh" ]; then bash scripts/claude_repo_setup.sh update || FAIL=1; else echo "scripts/claude_repo_setup.sh not found or not executable"; fi; \
+	if [ -x "scripts/claude_repo_setup.sh" ]; then $(BASH_BIN) scripts/claude_repo_setup.sh update || FAIL=1; else echo "scripts/claude_repo_setup.sh not found or not executable"; fi; \
 	echo "==> Applying Uninstall/ files..."; \
 	$(MAKE) -s uninstall REMOVE_SKIP_BASENAMES="$$VM_SKIP" || FAIL=1; \
 	echo "==> Applying RemoveAndPurge/ files..."; \
 	$(MAKE) -s remove-and-purge REMOVE_SKIP_BASENAMES="$$VM_SKIP" || FAIL=1; \
-	if [ -z "$$VM_SKIP" ]; then bash scripts/strip_asdf_zshrc_lines.sh || FAIL=1; fi; \
+	if [ -z "$$VM_SKIP" ]; then $(BASH_BIN) scripts/strip_asdf_zshrc_lines.sh || FAIL=1; fi; \
 	echo "==> All packages updated."; \
 	exit $$FAIL
 
@@ -689,7 +705,7 @@ update: require-dasel ## Update Homebrew, upgrade formulae/casks/MAS/managed too
 # top of this file) and is forwarded to scripts/self_update.sh so
 # `make self-update DRY_RUN=1` rehearses without making changes.
 self-update: ## Pull latest main; auto-stash if dirty (DRY_RUN=1 to rehearse)
-	@bash scripts/self_update.sh $(DRY_RUN_FLAG)
+	@$(BASH_BIN) scripts/self_update.sh $(DRY_RUN_FLAG)
 
 # --- Help ---
 help: ## Show help for available targets (documented + auto-detected Install/Uninstall/RemoveAndPurge + alias targets)
@@ -719,19 +735,19 @@ help: ## Show help for available targets (documented + auto-detected Install/Uni
 .PHONY: versions-install versions-update versions-outdated versions-cleanup versions-cleanup-dry-run asdf-to-mise
 
 versions-install: ## Install the tool versions the resolved mise config declares
-	@bash -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) install; else echo "$(VERSIONS_SETUP) not found"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) install; else echo "$(VERSIONS_SETUP) not found"; fi'
 
 versions-update: ## Install latest tool versions and bump the config (mise up --bump)
-	@bash -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) update; else echo "$(VERSIONS_SETUP) not found"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) update; else echo "$(VERSIONS_SETUP) not found"; fi'
 
 versions-outdated: ## Check for outdated mise-managed tools
-	@bash -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) outdated; else echo "$(VERSIONS_SETUP) not found"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) outdated; else echo "$(VERSIONS_SETUP) not found"; fi'
 
 versions-cleanup: ## Prune unused installed tool versions (mise prune)
-	@bash -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) cleanup; else echo "$(VERSIONS_SETUP) not found"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) cleanup; else echo "$(VERSIONS_SETUP) not found"; fi'
 
 versions-cleanup-dry-run: ## Show what versions-cleanup would remove
-	@bash -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) cleanup-dry-run; else echo "$(VERSIONS_SETUP) not found"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) cleanup-dry-run; else echo "$(VERSIONS_SETUP) not found"; fi'
 
 # One-shot migration verb. A deliberate exception to the
 # implementation-neutral naming above: it names both endpoints on purpose,
@@ -742,11 +758,11 @@ versions-cleanup-dry-run: ## Show what versions-cleanup would remove
 # and warns about leftovers, and deletes, moves, untracks, and commits
 # nothing.
 asdf-to-mise: ## Convert the calling repo from asdf+direnv to mise (additive; deletes nothing)
-	@START_DIR="$(START_DIR)" bash scripts/asdf_to_mise.sh
+	@START_DIR="$(START_DIR)" $(BASH_BIN) scripts/asdf_to_mise.sh
 
 04_Install_versionmanagers: ## Apply $(INSTALL_DIR)/$(VM_INSTALL) and set up mise
 	$(call APPLY_INSTALL_TIERS,$(VM_INSTALL))
-	@bash -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) full; else echo "[versionmanagers] $(VERSIONS_SETUP) not found or not executable"; fi'
+	@$(BASH_BIN) -lc 'if [ -x "$(VERSIONS_SETUP)" ]; then $(VERSIONS_SETUP) full; else echo "[versionmanagers] $(VERSIONS_SETUP) not found or not executable"; fi'
 
 # Allows: `make 02`, `make ui`, `make shell`, `make versionmanagers`, etc.
 
@@ -798,20 +814,20 @@ contentviewers: ; @$(MAKE) $(call CANON,19-Install.contentviewers)
 .PHONY: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 ai aws backups browsers componentization contentviewers core data databases development messaging msoffice proton ripping sdcards security shell tools ui versionmanagers
 
 diagnose: ## Run system diagnostics and check installation status
-	@bash ./scripts/diagnose.sh
+	@$(BASH_BIN) ./scripts/diagnose.sh
 .PHONY: diagnose
 
 .PHONY: verify sanitize
 verify: require-dasel ## Verify installations and check for same-tier Install/Uninstall+RemoveAndPurge collisions
 	@set -uo pipefail; FAIL=0; \
-	bash ./scripts/verify.sh || FAIL=1; \
+	$(BASH_BIN) ./scripts/verify.sh || FAIL=1; \
 	echo; \
 	echo "=== same-tier collision check ==="; \
-	bash ./scripts/collision_check.sh || FAIL=1; \
+	$(BASH_BIN) ./scripts/collision_check.sh || FAIL=1; \
 	exit $$FAIL
 
 sanitize: ## Resolve same-tier Install/Uninstall+RemoveAndPurge collisions by commenting out the Install line (writes .bak)
-	@bash ./scripts/collision_check.sh --fix
+	@$(BASH_BIN) ./scripts/collision_check.sh --fix
 
 .PHONY: outdated
 outdated: require-dasel ## Check for outdated formulae, casks, MAS apps, and managed tool versions
@@ -830,7 +846,7 @@ outdated: require-dasel ## Check for outdated formulae, casks, MAS apps, and man
 	@$(MAKE) -s versions-outdated 2>/dev/null || echo "  (unable to check)"
 	@echo
 	@echo "==> Pending updates in ~/.claude/ (global Claude config repo):"
-	@if [ -x "scripts/claude_repo_setup.sh" ]; then bash scripts/claude_repo_setup.sh outdated || true; else echo "  scripts/claude_repo_setup.sh not found or not executable"; fi
+	@if [ -x "scripts/claude_repo_setup.sh" ]; then $(BASH_BIN) scripts/claude_repo_setup.sh outdated || true; else echo "  scripts/claude_repo_setup.sh not found or not executable"; fi
 	@echo
 	@echo "To update all packages, run: make update"
 

--- a/Makefile
+++ b/Makefile
@@ -635,22 +635,31 @@ _remove_and_purge_loop:
 # Homebrew's "Error: <cask>: ..." format. If it changes, unmatched errors safely fall
 # through to the generic error check which sets FAIL=1.
 #
-# `update` also completes the asdf -> mise cutover, all three pieces of it:
-# it applies the slot-04 Install tiers (which is what puts `mise` on a host
-# that has never run `make install` -- `brew upgrade` upgrades an installed
-# formula but never installs an absent one), then the RemoveAndPurge loop
-# uninstalls asdf and direnv, then strip_asdf_zshrc_lines.sh removes the
-# ~/.zshrc init lines that would otherwise error on every shell startup.
-# `update` never runs shell_setup.sh, so without that last call the binaries
-# would go while their broken init lines stayed.
+# `update` also completes the asdf -> mise cutover end to end: it applies the
+# slot-04 Install tiers (which is what puts `mise` on a host that has never
+# run `make install` -- `brew upgrade` upgrades an installed formula but never
+# installs an absent one), then the RemoveAndPurge loop uninstalls asdf and
+# direnv, then it rewrites ~/.zshrc from both sides --
+# strip_asdf_zshrc_lines.sh removes the asdf/direnv init lines that would
+# otherwise error on every shell startup, and ensure_mise_zshrc_lines.sh adds
+# the mise shims PATH export and `mise activate zsh` that replace them.
+#
+# Both ~/.zshrc calls are here because `update` never runs shell_setup.sh, the
+# only other writer of those lines. Without the strip the binaries would go
+# while their broken init lines stayed; without the ensure (issue #38) a host
+# that reaches the cutover purely via `make update` would end it with mise
+# installed, asdf and direnv gone, and NO version manager wired into the
+# interactive shell at all.
 #
 # Order is load-bearing: INSTALL BEFORE REMOVE. The install step also runs
 # ahead of `versions-update`, which needs a mise to drive. If mise is still
 # not reachable after the install step -- brew bundle failed, the profile is
 # absent, the binary is off PATH -- the removal of asdf and direnv is skipped
 # via REMOVE_SKIP_BASENAMES (slot 04 only; every other slot still applies)
-# and so is the ~/.zshrc strip, because removing the old version manager
-# without a working replacement is strictly worse than leaving both in place.
+# and so are BOTH ~/.zshrc rewrites, because removing the old version manager
+# without a working replacement is strictly worse than leaving both in place --
+# and pointing ~/.zshrc at a mise that is not there would error on every shell
+# startup, which is the failure the strip exists to prevent.
 # That path warns and sets FAIL, so the run exits non-zero.
 update: require-dasel ## Update Homebrew, upgrade formulae/casks/MAS/managed tool versions, then apply Uninstall and RemoveAndPurge
 	@FAIL=0; \
@@ -697,7 +706,10 @@ update: require-dasel ## Update Homebrew, upgrade formulae/casks/MAS/managed too
 	$(MAKE) -s uninstall REMOVE_SKIP_BASENAMES="$$VM_SKIP" || FAIL=1; \
 	echo "==> Applying RemoveAndPurge/ files..."; \
 	$(MAKE) -s remove-and-purge REMOVE_SKIP_BASENAMES="$$VM_SKIP" || FAIL=1; \
-	if [ -z "$$VM_SKIP" ]; then $(BASH_BIN) scripts/strip_asdf_zshrc_lines.sh || FAIL=1; fi; \
+	if [ -z "$$VM_SKIP" ]; then \
+		$(BASH_BIN) scripts/strip_asdf_zshrc_lines.sh || FAIL=1; \
+		$(BASH_BIN) scripts/ensure_mise_zshrc_lines.sh || FAIL=1; \
+	fi; \
 	echo "==> All packages updated."; \
 	exit $$FAIL
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,15 @@ takes a `--mode={uninstall|purge}` flag (defaults to
 `uninstall` for backward compatibility); the Makefile
 passes the flag explicitly at every call site.
 
+The runner also exports `HOMEBREW_NO_AUTOREMOVE=1`, so a
+removal never cascades: `brew uninstall` normally follows
+up with an automatic `brew autoremove` that drops every
+formula nothing depends on any more, which is how
+uninstalling `asdf` once took Homebrew's `bash` formula
+with it mid-run. Pruning genuinely unneeded dependencies
+stays available as a deliberate, separate
+`brew autoremove`.
+
 See [docs/INSTALL.md](docs/INSTALL.md) for the full
 reference.
 
@@ -672,8 +681,9 @@ bounded to the scripts that name the tool directly:
 `scripts/versions_setup.sh` and `scripts/mise_common.sh`
 drive it, `scripts/diagnose.sh` reports on it,
 `scripts/asdf_to_mise.sh` migrates a repo onto it, and
-`scripts/shell_setup.sh` / `scripts/launchagent_runner.sh`
-put its shims on `PATH`.
+`scripts/ensure_mise_zshrc_lines.sh` (called by
+`scripts/shell_setup.sh` and by `make update`) /
+`scripts/launchagent_runner.sh` put its shims on `PATH`.
 
 ```bash
 # Install mise and its global config (included in make install).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -419,8 +419,13 @@ Homebrew bash mid-run made every later recipe line die with
 casualty that mattered was `make update`'s `~/.zshrc` strip: asdf and
 direnv were removed but their init lines stayed, erroring on every
 shell startup. `/bin/bash` ships with macOS and no Homebrew operation
-can remove it. `scripts/test/absolute_bash_test.sh` fails if a bare
-`bash` invocation is reintroduced, or if the export above is dropped.
+can remove it. The same holds for the scripts that re-invoke bash
+themselves: `shell_setup.sh` and `claude_repo_setup.sh` run their
+helper scripts under `/bin/bash`, and
+`ensure_mise_zshrc_lines.sh` runs its reachability probe under
+`/bin/bash -lc`. `scripts/test/absolute_bash_test.sh` fails if a bare
+`bash` invocation is reintroduced into the Makefile, `shell_setup.sh`,
+or `claude_repo_setup.sh`, or if the export above is dropped.
 
 ## See also
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -397,6 +397,31 @@ Mac App Store, or real `sudo`.
 `scripts/test/remove_runner_brew_override_test.sh` fails if a bare
 `brew`, `mas`, or `sudo` call is reintroduced into the runner.
 
+### Removals never cascade, and never lose the interpreter
+
+Two invariants keep a removal run from breaking its own later steps.
+
+`scripts/remove_runner.sh` exports `HOMEBREW_NO_AUTOREMOVE=1`. By
+default `brew uninstall` follows up with an automatic `brew autoremove`
+that drops every formula nothing depends on any more — which is how
+uninstalling `asdf` once took Homebrew's `bash` formula with it
+mid-run. The runner is the one place both removal trees actually call
+`brew`, so the export covers `make uninstall`, `make remove-and-purge`,
+both of `make update`'s loops, and the slot-04 purge `make install`
+applies inline. Pruning genuinely unneeded dependencies stays available
+as a deliberate, separate `brew autoremove`.
+
+Every Makefile recipe names bash as `$(BASH_BIN)` — the absolute
+`/bin/bash`, which is also `SHELL` — rather than a `PATH`-resolved bare
+`bash`. On a host whose `PATH` prefers `/opt/homebrew/bin`, losing the
+Homebrew bash mid-run made every later recipe line die with
+`/bin/bash: /opt/homebrew/bin/bash: No such file or directory`, and the
+casualty that mattered was `make update`'s `~/.zshrc` strip: asdf and
+direnv were removed but their init lines stayed, erroring on every
+shell startup. `/bin/bash` ships with macOS and no Homebrew operation
+can remove it. `scripts/test/absolute_bash_test.sh` fails if a bare
+`bash` invocation is reintroduced, or if the export above is dropped.
+
 ## See also
 
 - [Makefile Usage](MAKEFILE.md)

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -405,8 +405,8 @@ so swapping the implementation leaves the target names, their callers,
 and the doc lines that reference them alone — the change is bounded to
 the scripts that name the tool directly
 (`scripts/versions_setup.sh`, `scripts/mise_common.sh`, and the
-shell/launchd `PATH` lines in `scripts/shell_setup.sh` and
-`scripts/launchagent_runner.sh`):
+shell/launchd `PATH` lines in `scripts/ensure_mise_zshrc_lines.sh`
+and `scripts/launchagent_runner.sh`):
 
 - `make versions-install` — install the versions the resolved mise
   config declares

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -4,6 +4,13 @@ This repository uses a dynamic `Makefile` to orchestrate applying
 `Install/` files (formerly `Brewfiles`) and the parallel `Uninstall/`
 and `RemoveAndPurge/` frameworks, plus related setup tasks.
 
+Every recipe runs under `BASH_BIN`, the absolute `/bin/bash`, which is
+also what `SHELL` is set from, and every helper script a recipe invokes
+is named as `$(BASH_BIN) scripts/<name>.sh` rather than a
+`PATH`-resolved bare `bash`. A run that removes Homebrew's `bash`
+formula must not lose the interpreter its own later steps need; see
+[Removals never cascade, and never lose the interpreter](INSTALL.md#removals-never-cascade-and-never-lose-the-interpreter).
+
 ## Common Targets
 
 - `make install`
@@ -107,6 +114,8 @@ and `RemoveAndPurge/` frameworks, plus related setup tasks.
   without touching real Homebrew, the real Mac App Store, or real
   `sudo`; see
   [Overriding the package-manager binaries](INSTALL.md#overriding-the-package-manager-binaries).
+  The runner also exports `HOMEBREW_NO_AUTOREMOVE=1`, so an uninstall
+  never cascades into a shared dependency.
 
 - `make uninstall-dry-run`
   Same as `make uninstall` but only prints what would happen. Safe to

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -138,11 +138,16 @@ and `RemoveAndPurge/` frameworks, plus related setup tasks.
   result. Slot 04 is the ONE `Install/` slot `update` applies; no
   other `Install/` file is re-applied.
 
-  It then calls `scripts/strip_asdf_zshrc_lines.sh`. The purge step
-  uninstalls `asdf` and `direnv`, and `update` never runs
-  `shell_setup.sh`, so without this call it would remove the binaries
-  and leave their `~/.zshrc` init lines erroring on every shell
-  startup. The script is a no-op once the lines are gone.
+  It then rewrites `~/.zshrc` from both sides:
+  `scripts/strip_asdf_zshrc_lines.sh` removes the asdf/direnv init
+  lines, and `scripts/ensure_mise_zshrc_lines.sh` adds the mise shims
+  `PATH` export and `eval "$(mise activate zsh)"` that replace them.
+  The purge step uninstalls `asdf` and `direnv`, and `update` never
+  runs `shell_setup.sh` — the only other writer of those lines — so
+  without the strip it would leave the old init lines erroring on
+  every shell startup, and without the add it would leave the host
+  with no version manager wired into the interactive shell at all.
+  Both scripts are grep-guarded no-ops once their work is done.
 
   Slot 04's `Install` runs first for the same reason: `brew upgrade`
   upgrades an installed formula but never installs an absent one, so
@@ -151,8 +156,9 @@ and `RemoveAndPurge/` frameworks, plus related setup tasks.
   precedes remove — and if the `MISE_REACHABLE` probe (the same macro
   `install` gates its inline purge on, so the two destructive paths
   cannot drift) still finds no mise after that install step, `update`
-  skips slot 04 in both removal loops and skips the strip, warns, and
-  exits non-zero, leaving every other removal slot to apply normally.
+  skips slot 04 in both removal loops and skips both `~/.zshrc`
+  rewrites, warns, and exits non-zero, leaving every other removal
+  slot to apply normally.
 
 - `make self-update`
   Pulls the latest `main` into this repo via `scripts/self_update.sh`.

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -152,7 +152,7 @@ formula must not lose the interpreter its own later steps need; see
   lines, and `scripts/ensure_mise_zshrc_lines.sh` adds the mise shims
   `PATH` export and `eval "$(mise activate zsh)"` that replace them.
   The purge step uninstalls `asdf` and `direnv`, and `update` never
-  runs `shell_setup.sh` — the only other writer of those lines — so
+  runs `shell_setup.sh` — the only other caller of that pair — so
   without the strip it would leave the old init lines erroring on
   every shell startup, and without the add it would leave the host
   with no version manager wired into the interactive shell at all.

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -114,6 +114,17 @@ shell startup. The shims `PATH` export is written unconditionally — a
 `PATH` entry naming a directory that does not exist yet is inert, and
 it is correct the moment mise lands.
 
+"On `PATH`" is decided by the same two-step probe the Makefile's
+`MISE_REACHABLE` macro uses: the calling shell's `PATH` first, then a
+login shell's (`/bin/bash -lc`). The login-shell half matters because a
+mise installed moments earlier in the same run lands on a login shell's
+`PATH`, not necessarily on make's — and `MISE_REACHABLE` is what lets
+`make update` remove asdf and direnv. If this script checked only make's
+`PATH`, the two gates could disagree within one run: the removal
+happens, the activation line is withheld, and the host ends the cutover
+with no version manager wired into the interactive shell — exactly the
+failure issue #38 exists to fix.
+
 Like the strip below, the script has more than one caller, and for the
 same reason:
 

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -114,9 +114,10 @@ shell startup. The shims `PATH` export is written unconditionally — a
 `PATH` entry naming a directory that does not exist yet is inert, and
 it is correct the moment mise lands.
 
-"On `PATH`" is decided by the same two-step probe the Makefile's
-`MISE_REACHABLE` macro uses: the calling shell's `PATH` first, then a
-login shell's (`/bin/bash -lc`). The login-shell half matters because a
+"On `PATH`" is decided in two steps: the calling shell's `PATH` first,
+then a fallback to `/bin/bash -lc` — which is exactly what the
+Makefile's `MISE_REACHABLE` macro is. The login-shell half matters
+because a
 mise installed moments earlier in the same run lands on a login shell's
 `PATH`, not necessarily on make's — and `MISE_REACHABLE` is what lets
 `make update` remove asdf and direnv. If this script checked only make's

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -99,7 +99,7 @@ macos-setup itself) in `shared/zsh/` instead.
 
 ## mise init lines
 
-`make shell` (via `scripts/shell_setup.sh`) idempotently appends the
+`scripts/ensure_mise_zshrc_lines.sh` idempotently appends the
 following to `~/.zshrc` (each line at most once):
 
 ```zsh
@@ -107,10 +107,28 @@ export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"
 eval "$(mise activate zsh)"
 ```
 
-The activation line is written only once `mise` is on `PATH`; a
-`make shell` that runs before `mise` is installed says so and adds
-the line on the next run. The shims `PATH` export is written
-unconditionally.
+The activation line is written only once `mise` is on `PATH`; a run
+before `mise` is installed says so and adds the line on the next one.
+Pointing `~/.zshrc` at a mise that is not there would error on every
+shell startup. The shims `PATH` export is written unconditionally — a
+`PATH` entry naming a directory that does not exist yet is inert, and
+it is correct the moment mise lands.
+
+Like the strip below, the script has more than one caller, and for the
+same reason:
+
+- `make shell` / `make install`, via `scripts/shell_setup.sh`.
+- `make update`, which calls it directly — it installs mise and
+  uninstalls asdf and direnv but never runs `shell_setup.sh`, so
+  without the direct call a host that goes through the cutover purely
+  via `make update` would end it with no version manager wired into
+  the interactive shell at all (issue #38).
+
+`ZSHRC_PATH` overrides the file it edits and `MISE` overrides the
+binary the reachability check looks for (both so the test suite can
+drive the script against a fixture); the line written into `~/.zshrc`
+always names bare `mise` regardless of `MISE`, because that is what
+your interactive shell will find.
 
 Both forms are emitted on purpose. `mise activate zsh` is mise's
 preferred interactive form and is what makes `cd` into a project
@@ -126,7 +144,11 @@ reason (the same pattern it uses for `HOMEBREW_NO_ASK`).
 ### Migrating off asdf + direnv
 
 The `version-managers` profile moved from asdf + direnv to mise. The
-strip lives in `scripts/strip_asdf_zshrc_lines.sh` and removes the
+`~/.zshrc` half of that cutover is a pair of scripts — the strip below
+and the add above — and every caller runs both, in that order, so the
+two cutover paths leave `~/.zshrc` in the same state.
+
+The strip lives in `scripts/strip_asdf_zshrc_lines.sh` and removes the
 `~/.zshrc` lines that the change orphaned:
 
 - `. /opt/homebrew/opt/asdf/libexec/asdf.sh` — already dead before
@@ -149,6 +171,12 @@ either of the paths below, and each must leave `~/.zshrc` clean:
   and direnv through the `RemoveAndPurge` loop but never runs
   `shell_setup.sh`, so without the direct call it would remove the
   binaries and leave their broken init lines behind.
+
+On the `make update` path both rewrites sit behind the same guard as
+the asdf/direnv removal: if mise is still not reachable after the
+slot-04 install, `update` skips the removal and both `~/.zshrc`
+rewrites, warns, and exits non-zero. See
+[Version Management](VERSION_MANAGEMENT.md).
 
 `ZSHRC_PATH` overrides the file it edits (the test suite points it at
 a fixture); it defaults to `~/.zshrc`.

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -24,7 +24,8 @@ implements them, so swapping the implementation again leaves the
 public interface — target names, aliases, and doc lines — alone. The
 change is bounded to the places that name the tool directly:
 `scripts/versions_setup.sh`, `scripts/mise_common.sh`, the `~/.zshrc`
-init lines in `scripts/shell_setup.sh`, the shims `PATH` export in
+init lines in `scripts/ensure_mise_zshrc_lines.sh`, the shims `PATH`
+export in
 `scripts/launchagent_runner.sh`, `scripts/diagnose.sh`, and the
 `version-managers` profile's `Install/04-Install.versionmanagers`.
 

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -191,14 +191,22 @@ Separate pieces of work, each owned by a different mechanism:
 | Install `mise` | slot 04's `Install` + `versions_setup.sh full` |
 | Uninstall `asdf` + `direnv` | slot 04's `RemoveAndPurge` |
 | Strip orphaned `~/.zshrc` lines | `strip_asdf_zshrc_lines.sh` |
+| Add the mise `~/.zshrc` lines | `ensure_mise_zshrc_lines.sh` |
+
+The last two are a pair, and both are their own script for the same
+reason: the cutover reaches a host down either of two paths, and each
+must leave `~/.zshrc` in the same state. Stripping without adding is
+what left a real host with mise installed, asdf and direnv gone, and
+no version manager wired into the interactive shell at all.
 
 **`make install` and `make update` each do all of it.** `make install`
 runs the slot-04 install and, as a deliberate one-slot exception to
 "install does not run the removal loops", the slot-04 RemoveAndPurge
-alongside it; the `03-Install.shell` action strips `~/.zshrc`.
-`make update` applies the slot-04 `Install` tiers itself before it
-reaches the removal loops, then runs those loops and calls the strip
-script directly (it never runs `shell_setup.sh`). The explicit install
+alongside it; the `03-Install.shell` action rewrites `~/.zshrc` from
+both sides. `make update` applies the slot-04 `Install` tiers itself
+before it reaches the removal loops, then runs those loops and calls
+the strip and the add directly, in that order (it never runs
+`shell_setup.sh`). The explicit install
 step is what carries a host that has never run `make install`:
 `brew upgrade` upgrades a formula that is already installed but never
 installs an absent one, so without it `update` would remove asdf and
@@ -210,7 +218,10 @@ anything, through one shared Makefile macro (`MISE_REACHABLE`), and
 hold the removal back when the probe fails — `brew bundle` failed,
 the host never opted into the `version-managers` profile, the binary
 is off `PATH`. `make update` skips slot 04's `Uninstall` and
-`RemoveAndPurge` and skips the `~/.zshrc` strip; `make install` skips
+`RemoveAndPurge` and skips both `~/.zshrc` rewrites — pointing
+`~/.zshrc` at a mise that is not there would error on every shell
+startup, which is exactly what the strip exists to prevent;
+`make install` skips
 its inline slot-04 `RemoveAndPurge`. Both warn and exit non-zero.
 Every other slot still applies; only slot 04 is held back. A host is
 never left with the old version manager gone and no replacement.
@@ -229,7 +240,7 @@ Driving the cutover by hand therefore takes the sequence:
 ```bash
 make versionmanagers                       # install mise
 make 04_RemoveAndPurge_versionmanagers     # uninstall asdf + direnv
-make shell                                 # strip the ~/.zshrc lines
+make shell                                 # rewrite the ~/.zshrc lines
 ```
 
 Removing the binaries touches none of the data they left behind:

--- a/scripts/claude_repo_setup.sh
+++ b/scripts/claude_repo_setup.sh
@@ -207,7 +207,11 @@ sync_claude_plugins() {
 
     info "Syncing Claude plugins via $CLAUDE_PLUGINS_SCRIPT $flag..."
     local rc=0
-    bash "$CLAUDE_PLUGINS_SCRIPT" "$flag" || rc=$?
+    # Absolute /bin/bash, not a PATH-resolved bare `bash` (issue #37): a
+    # removal earlier in the same `make install` / `make update` run can take
+    # Homebrew's bash out from under a PATH that prefers it, and /bin/bash is
+    # the one bash no Homebrew operation can remove.
+    /bin/bash "$CLAUDE_PLUGINS_SCRIPT" "$flag" || rc=$?
     return $rc
 }
 

--- a/scripts/ensure_mise_zshrc_lines.sh
+++ b/scripts/ensure_mise_zshrc_lines.sh
@@ -33,6 +33,17 @@
 # gated — a PATH entry pointing at a directory that does not exist yet is
 # inert, and it is correct the moment mise lands.
 #
+# That reachability decision must agree with the Makefile's MISE_REACHABLE
+# probe, which is what let `update` remove asdf and direnv in the first place.
+# MISE_REACHABLE runs under `/bin/bash -lc` precisely because a mise installed
+# moments earlier in the same run lands on a LOGIN shell's PATH, not
+# necessarily on make's. A plain `command -v` here would see only make's
+# non-login PATH, so the two gates could disagree within one run: the probe
+# passes, the old version manager goes, and the activation line is withheld —
+# exactly the fresh-install scenario issue #38 exists to fix. So the gate below
+# checks this shell's PATH first and falls back to the same login-shell probe
+# the Makefile uses.
+#
 # ZSHRC_PATH is overridable so the test suite can point it at a fixture, and
 # MISE is overridable (the same knob scripts/mise_common.sh reads) so a test
 # can drive both the reachable and unreachable branches. MISE gates the
@@ -57,7 +68,15 @@ _ms_ensure_line() {
 
 _ms_ensure_line 'export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"' "$ZSHRC_PATH"
 
-if command -v "$MISE" >/dev/null 2>&1; then
+# Mirrors the Makefile's MISE_REACHABLE macro: this shell's PATH first, then a
+# login shell's, so the two gates cannot disagree within one run. MISE is
+# passed through explicitly because it is a shell variable here, not exported.
+_ms_mise_reachable() {
+  command -v "$MISE" >/dev/null 2>&1 && return 0
+  MISE="$MISE" /bin/bash -lc 'command -v "${MISE:-mise}" >/dev/null 2>&1'
+}
+
+if _ms_mise_reachable; then
   _ms_ensure_line 'eval "$(mise activate zsh)"' "$ZSHRC_PATH"
 else
   echo "[SHELL-SETUP] NOTE: mise not yet installed; activation line will be added after install."

--- a/scripts/ensure_mise_zshrc_lines.sh
+++ b/scripts/ensure_mise_zshrc_lines.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# ensure_mise_zshrc_lines.sh — add the mise init lines to ~/.zshrc, once.
+#
+# Both forms are emitted, on purpose:
+#   - `mise activate zsh` is mise's preferred interactive form and is what
+#     makes `cd` into a project switch tool versions (and, with
+#     `[settings] env_file`, load its `.env`).
+#   - the shims dir on PATH covers every non-interactive context that never
+#     sources ~/.zshrc at all.
+#
+# The shims path is mise's own default install location. The literal below is
+# written into ~/.zshrc, so it cannot be sourced from `mise_shims_dir` in
+# scripts/mise_common.sh; that function states the same path, and
+# scripts/launchagent_runner.sh repeats the literal a third time to put the
+# directory on PATH for scheduled jobs (launchd does NOT source ~/.zshrc).
+# Change one, change all three.
+#
+# This is the ADD half of the asdf -> mise cutover's ~/.zshrc work;
+# scripts/strip_asdf_zshrc_lines.sh is the REMOVE half. Both are their own
+# script for the same reason: the cutover reaches a host down either of two
+# paths, and each must leave ~/.zshrc in the same state (issue #38).
+#   - scripts/shell_setup.sh (the `03-Install.shell` post-install action),
+#     i.e. `make install` and `make shell`.
+#   - the `update` Makefile target, which installs mise and uninstalls
+#     asdf/direnv but never runs shell_setup.sh. Without this call a host
+#     that only ever runs `make update` ends the cutover with mise installed,
+#     the old version manager gone, and NO version manager wired into the
+#     interactive shell.
+#
+# The activation line is gated on mise actually being reachable: a ~/.zshrc
+# that evals an absent binary errors on every shell startup, which is the
+# failure this whole cutover exists to avoid. The shims PATH export is not
+# gated — a PATH entry pointing at a directory that does not exist yet is
+# inert, and it is correct the moment mise lands.
+#
+# ZSHRC_PATH is overridable so the test suite can point it at a fixture, and
+# MISE is overridable (the same knob scripts/mise_common.sh reads) so a test
+# can drive both the reachable and unreachable branches. MISE gates the
+# reachability decision ONLY — the line written into ~/.zshrc always names
+# bare `mise`, because that is what the user's interactive shell will find.
+#
+# Run: /bin/bash scripts/ensure_mise_zshrc_lines.sh
+
+set -euo pipefail
+
+ZSHRC_PATH="${ZSHRC_PATH:-$HOME/.zshrc}"
+MISE="${MISE:-mise}"
+
+_ms_ensure_line() {
+  local line="$1" file="$2"
+  [ -f "$file" ] || touch "$file"
+  if ! grep -Fqx "$line" "$file" 2>/dev/null; then
+    echo "$line" >> "$file"
+    echo "[SHELL-SETUP] appended to $file: $line"
+  fi
+}
+
+_ms_ensure_line 'export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"' "$ZSHRC_PATH"
+
+if command -v "$MISE" >/dev/null 2>&1; then
+  _ms_ensure_line 'eval "$(mise activate zsh)"' "$ZSHRC_PATH"
+else
+  echo "[SHELL-SETUP] NOTE: mise not yet installed; activation line will be added after install."
+fi

--- a/scripts/ensure_mise_zshrc_lines.sh
+++ b/scripts/ensure_mise_zshrc_lines.sh
@@ -68,9 +68,11 @@ _ms_ensure_line() {
 
 _ms_ensure_line 'export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"' "$ZSHRC_PATH"
 
-# Mirrors the Makefile's MISE_REACHABLE macro: this shell's PATH first, then a
-# login shell's, so the two gates cannot disagree within one run. MISE is
-# passed through explicitly because it is a shell variable here, not exported.
+# This shell's PATH first, then the login-shell probe the Makefile's
+# MISE_REACHABLE macro is, so the two gates cannot disagree within one run.
+# (The fallback is the whole of MISE_REACHABLE; the fast path is an extra
+# allowance for a mise make can see but a login shell cannot.) MISE is passed
+# through explicitly because it is a shell variable here, not exported.
 _ms_mise_reachable() {
   command -v "$MISE" >/dev/null 2>&1 && return 0
   MISE="$MISE" /bin/bash -lc 'command -v "${MISE:-mise}" >/dev/null 2>&1'

--- a/scripts/launchagent_runner.sh
+++ b/scripts/launchagent_runner.sh
@@ -86,7 +86,8 @@ export HOMEBREW_NO_ASK=1
 # Put mise's shims on PATH for every scheduled job. Same reasoning as
 # HOMEBREW_NO_ASK above: launchd does NOT source ~/.zshrc, so neither the
 # `mise activate zsh` line nor the shims PATH export that
-# scripts/shell_setup.sh writes there reaches this runner. Without the
+# scripts/ensure_mise_zshrc_lines.sh writes there reaches this runner.
+# Without the
 # shims, a scheduled `make update` resolves whatever `node`/`python`/... is
 # on launchd's bare PATH rather than the mise-managed version.
 #
@@ -96,8 +97,8 @@ export HOMEBREW_NO_ASK=1
 # entry point. The path is mise's own default install location; it is
 # stated identically by `mise_shims_dir` in scripts/mise_common.sh, which
 # this runner cannot source (the repo root is not resolved yet at this
-# point), and a third time by scripts/shell_setup.sh, which writes the
-# literal into ~/.zshrc. Change one, change all three.
+# point), and a third time by scripts/ensure_mise_zshrc_lines.sh, which
+# writes the literal into ~/.zshrc. Change one, change all three.
 export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"
 
 if [[ $# -lt 2 ]]; then

--- a/scripts/mise_common.sh
+++ b/scripts/mise_common.sh
@@ -37,11 +37,12 @@ mise_global_config_path() {
 
 # Directory mise installs its shims into — mise's own default location.
 # This is the canonical statement of that path, but it is not the only
-# one: shell_setup.sh and launchagent_runner.sh each repeat the literal,
-# and neither calls this function. They cannot. shell_setup.sh writes the
-# expression into ~/.zshrc, which must not depend on this repo being
-# present; launchagent_runner.sh needs it on PATH before the repo root is
-# resolved, so it has nothing to source. Keep all three in sync by hand.
+# one: ensure_mise_zshrc_lines.sh and launchagent_runner.sh each repeat the
+# literal, and neither calls this function. They cannot.
+# ensure_mise_zshrc_lines.sh writes the expression into ~/.zshrc, which must
+# not depend on this repo being present; launchagent_runner.sh needs it on
+# PATH before the repo root is resolved, so it has nothing to source. Keep
+# all three in sync by hand.
 mise_shims_dir() {
   printf '%s/mise/shims\n' "${XDG_DATA_HOME:-$HOME/.local/share}"
 }

--- a/scripts/remove_runner.sh
+++ b/scripts/remove_runner.sh
@@ -199,6 +199,18 @@ BREW="${BREW:-brew}"
 MAS="${MAS:-mas}"
 SUDO="${SUDO:-sudo}"
 
+# Stop `brew uninstall` from cascading into shared dependencies (issue #37).
+# By default `brew uninstall` follows up with an automatic `brew autoremove`,
+# which removes every formula nothing declares a dependency on any more. That
+# is how uninstalling asdf took Homebrew's `bash` formula with it mid-run, and
+# a run that deletes the interpreter its own later steps need cannot finish.
+# This runner is the ONE place both removal trees (Uninstall/ and
+# RemoveAndPurge/) actually call brew, so exporting it here covers `make
+# uninstall`, `make remove-and-purge`, `make update`'s two loops, and the
+# slot-04 purge `make install` applies inline. Removing genuinely unneeded
+# dependencies stays available as a deliberate, separate `brew autoremove`.
+export HOMEBREW_NO_AUTOREMOVE=1
+
 is_brew_installed() {
   "$BREW" list --formula "$1" >/dev/null 2>&1
 }

--- a/scripts/shell_setup.sh
+++ b/scripts/shell_setup.sh
@@ -265,7 +265,12 @@ ZSHRC_PATH="$HOME/.zshrc"
 #    needs the same strip and does not run this script: it uninstalls asdf
 #    and direnv via the RemoveAndPurge loop, which would otherwise leave a
 #    broken `direnv hook` line erroring on every shell startup.
-ZSHRC_PATH="$ZSHRC_PATH" bash "$SCRIPT_DIR/strip_asdf_zshrc_lines.sh"
+#
+#    Absolute /bin/bash, not a PATH-resolved bare `bash` (issue #37): the
+#    same `make install` run that reaches this script also uninstalls asdf
+#    and direnv, and a `brew uninstall` that cascades into Homebrew's bash
+#    formula would otherwise break this call on a PATH that prefers it.
+ZSHRC_PATH="$ZSHRC_PATH" /bin/bash "$SCRIPT_DIR/strip_asdf_zshrc_lines.sh"
 
 # 2) Ensure the mise init lines.
 #

--- a/scripts/shell_setup.sh
+++ b/scripts/shell_setup.sh
@@ -246,16 +246,12 @@ fi
 # <<< macos-setup zoxide init <<<
 
 # >>> macos-setup mise init >>>
-# Idempotent mise initialization (appends to ~/.zshrc only if missing)
-_ms_ensure_line() {
-  local line="$1" file="$2"
-  [ -f "$file" ] || touch "$file"
-  if ! grep -Fqx "$line" "$file" 2>/dev/null; then
-    echo "$line" >> "$file"
-    echo "[SHELL-SETUP] appended to $file: $line"
-  fi
-}
-
+# Idempotent mise initialization (appends to ~/.zshrc only if missing).
+#
+# Both halves — remove the orphaned asdf/direnv lines, add the mise ones —
+# live in their own script rather than inline here, because the `update`
+# Makefile target must do exactly the same two things and never runs this
+# script (issue #38).
 ZSHRC_PATH="$HOME/.zshrc"
 
 # 1) Remove the ~/.zshrc lines the asdf -> mise migration orphans.
@@ -274,25 +270,12 @@ ZSHRC_PATH="$ZSHRC_PATH" /bin/bash "$SCRIPT_DIR/strip_asdf_zshrc_lines.sh"
 
 # 2) Ensure the mise init lines.
 #
-#    Both forms are emitted, on purpose:
-#      - `mise activate zsh` is mise's preferred interactive form and is
-#        what makes `cd` into a project switch tool versions (and, with
-#        `[settings] env_file`, load its `.env`).
-#      - the shims dir on PATH covers every non-interactive context that
-#        never sources this file at all.
-#
-#    The shims path is mise's own default install location. The literal
-#    below is written into ~/.zshrc, so it cannot be sourced from
-#    `mise_shims_dir` in scripts/mise_common.sh; that function states the
-#    same path, and scripts/launchagent_runner.sh repeats the literal a
-#    third time to put the directory on PATH for scheduled jobs (launchd
-#    does NOT source ~/.zshrc). Change one, change all three.
-_ms_ensure_line 'export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims:$PATH"' "$ZSHRC_PATH"
-if command -v mise >/dev/null 2>&1; then
-  _ms_ensure_line 'eval "$(mise activate zsh)"' "$ZSHRC_PATH"
-else
-  echo "[SHELL-SETUP] NOTE: mise not yet installed; activation line will be added after install."
-fi
+#    Which lines, why both of them, and why the activation line is gated on
+#    mise being reachable all live in
+#    scripts/ensure_mise_zshrc_lines.sh — the same reason as the strip
+#    above: the `update` Makefile target needs this identical work and does
+#    not run this script.
+ZSHRC_PATH="$ZSHRC_PATH" /bin/bash "$SCRIPT_DIR/ensure_mise_zshrc_lines.sh"
 # <<< macos-setup mise init <<<
 
 # >>> macos-setup PATH and claude symlink >>>

--- a/scripts/test/absolute_bash_test.sh
+++ b/scripts/test/absolute_bash_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Tests for the "no PATH-resolved bash" invariant (issue #37).
+#
+# WHY THIS EXISTS. Recipes used to invoke helper scripts as
+# `bash scripts/foo.sh` — a bare name resolved through PATH. On a host whose
+# PATH puts /opt/homebrew/bin first, the asdf -> mise cutover's slot-04
+# RemoveAndPurge uninstalled asdf, `brew uninstall`'s automatic
+# `brew autoremove` took Homebrew's `bash` formula with it as an unneeded
+# dependency, and every LATER recipe line died with:
+#
+#   /bin/bash: /opt/homebrew/bin/bash: No such file or directory
+#
+# The casualty that mattered was `make update`'s ~/.zshrc strip: the run
+# removed asdf and direnv but never removed their init lines, so the host
+# errored on every shell startup afterwards. A run that deletes the
+# interpreter its own later steps need cannot finish.
+#
+# Two independent defenses, one block each:
+#
+#   Block 1 (static): every bash invocation in the Makefile names
+#   $(BASH_BIN), which is the absolute /bin/bash — the one bash no Homebrew
+#   operation can remove. Same check for the two scripts that re-invoke bash
+#   directly. The check is self-verifying: it is re-run against a
+#   deliberately mutated copy that reintroduces a bare `bash`, and must FIRE
+#   there, so a pattern that silently stops matching cannot pass.
+#
+#   Block 2 (static): scripts/remove_runner.sh — the ONE place both removal
+#   trees actually call brew — exports HOMEBREW_NO_AUTOREMOVE=1, so an
+#   uninstall never cascades into a shared dependency in the first place.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MAKEFILE="$REPO_ROOT/Makefile"
+
+pass=0
+fail=0
+ok() {
+  # ok <condition-rc> <label>
+  if [[ "$1" == "0" ]]; then echo "PASS: $2"; ((pass++)); else echo "FAIL: $2"; ((fail++)); fi
+}
+
+# A bash COMMAND invocation: the word `bash` not preceded by a path
+# character or word character (so `/bin/bash`, `$(BASH_BIN)` and the word
+# "bash" inside a longer identifier do not match), followed by an argument.
+# Comment lines are excluded — prose naming the hazard is not the hazard.
+BARE_BASH_RE='^[^#]*(^|[^[:alnum:]_./$)-])bash[[:space:]]+[^[:space:]]'
+
+bare_bash_hits() {
+  # bare_bash_hits <file> -> prints offending lines (if any)
+  grep -nE "$BARE_BASH_RE" "$1" | grep -vE '^[0-9]+:[[:space:]]*#'
+}
+
+no_bare_bash() {
+  # no_bare_bash <file> <label>
+  local hits
+  hits="$(bare_bash_hits "$1")"
+  if [[ -z "$hits" ]]; then
+    echo "PASS: $2"; ((pass++))
+  else
+    echo "FAIL: $2 -- PATH-resolved bash at:"; echo "$hits"; ((fail++))
+  fi
+}
+
+# ---------------------------------------------------------------------
+# Block 1: no PATH-resolved bash anywhere that runs during make.
+# ---------------------------------------------------------------------
+absolute_bash_test() {
+  ok "$(grep -qE '^BASH_BIN[[:space:]]*:=[[:space:]]*/bin/bash$' "$MAKEFILE" && echo 0 || echo 1)" \
+    "Makefile defines BASH_BIN as the absolute /bin/bash"
+  ok "$(grep -qE '^SHELL[[:space:]]*:=[[:space:]]*\$\(BASH_BIN\)$' "$MAKEFILE" && echo 0 || echo 1)" \
+    "make's own recipe shell is BASH_BIN, so the path is stated once"
+
+  no_bare_bash "$MAKEFILE" "no PATH-resolved bash in the Makefile"
+  no_bare_bash "$REPO_ROOT/scripts/shell_setup.sh" \
+    "no PATH-resolved bash in shell_setup.sh"
+  no_bare_bash "$REPO_ROOT/scripts/claude_repo_setup.sh" \
+    "no PATH-resolved bash in claude_repo_setup.sh"
+
+  # Self-verification: the pattern must FIRE on a copy that reintroduces the
+  # exact form this test exists to forbid.
+  local mutated
+  mutated="$(mktemp)"
+  sed 's|\$(BASH_BIN) scripts/self_update.sh|bash scripts/self_update.sh|' \
+    "$MAKEFILE" > "$mutated"
+  ok "$([[ -n "$(bare_bash_hits "$mutated")" ]] && echo 0 || echo 1)" \
+    "the bare-bash pattern fires on a mutated Makefile (self-check)"
+  rm -f "$mutated"
+}
+
+# ---------------------------------------------------------------------
+# Block 2: uninstalls do not cascade into shared dependencies.
+# ---------------------------------------------------------------------
+no_autoremove_test() {
+  ok "$(grep -qE '^export HOMEBREW_NO_AUTOREMOVE=1$' "$REPO_ROOT/scripts/remove_runner.sh" \
+    && echo 0 || echo 1)" \
+    "remove_runner.sh exports HOMEBREW_NO_AUTOREMOVE=1"
+}
+
+echo "=== Block 1: no PATH-resolved bash ==="
+absolute_bash_test
+echo "=== Block 2: no cascading autoremove ==="
+no_autoremove_test
+
+echo
+echo "---"
+echo "pass=$pass fail=$fail"
+if [[ $fail -eq 0 ]]; then
+  echo "All absolute-bash tests passed."
+  exit 0
+fi
+echo "Some absolute-bash tests FAILED."
+exit 1

--- a/scripts/test/absolute_bash_test.sh
+++ b/scripts/test/absolute_bash_test.sh
@@ -20,8 +20,11 @@
 #
 #   Block 1 (static): every bash invocation in the Makefile names
 #   $(BASH_BIN), which is the absolute /bin/bash — the one bash no Homebrew
-#   operation can remove. Same check for the two scripts that re-invoke bash
-#   directly. The check is self-verifying: it is re-run against a
+#   operation can remove. Same check for scripts/shell_setup.sh and
+#   scripts/claude_repo_setup.sh, which re-invoke bash to run a helper
+#   script. (scripts/ensure_mise_zshrc_lines.sh also re-invokes bash, for its
+#   `/bin/bash -lc` reachability probe, and is not scanned here.)
+#   The check is self-verifying: it is re-run against a
 #   deliberately mutated copy that reintroduces a bare `bash`, and must FIRE
 #   there, so a pattern that silently stops matching cannot pass.
 #

--- a/scripts/test/ensure_mise_zshrc_lines_test.sh
+++ b/scripts/test/ensure_mise_zshrc_lines_test.sh
@@ -92,6 +92,33 @@ check "case 5: existing comment kept" "$(grep -c 'my own line' "$Z5")" "1"
 check "case 5: existing export kept"  "$(grep -c 'export FOO=1' "$Z5")" "1"
 check "case 5: shims PATH export added" "$(grep -cF "$SHIMS_LINE" "$Z5")" "1"
 
+# === case 6: a bare-name mise on this shell's PATH is reachable =========
+# The fast path of the two-step gate: no login shell needed when make's own
+# PATH already has it.
+Z6="$SANDBOX/case6-zshrc"
+: > "$Z6"
+OUT="$(ZSHRC_PATH="$Z6" MISE="mise" PATH="$SANDBOX:$PATH" /bin/bash "$SUT" 2>&1)"; RC=$?
+check "case 6: exits zero" "$RC" "0"
+check "case 6: activation line added" "$(grep -cFx "$ACTIVATE_LINE" "$Z6")" "1"
+
+# === case 7: the gate matches the Makefile's MISE_REACHABLE probe ========
+# `update` decides to remove asdf and direnv with MISE_REACHABLE, which runs
+# under a LOGIN shell because a mise installed moments earlier in the same run
+# lands on a login shell's PATH, not necessarily on make's. If this script
+# checked only make's PATH the two gates could disagree within one run — the
+# removal happens, the activation line is withheld. So the script must fall
+# back to the same login-shell probe.
+if grep -qE '/bin/bash -lc .*command -v' "$SUT"; then
+  ok "case 7: the gate falls back to a login-shell probe"
+else
+  bad "case 7: the gate falls back to a login-shell probe"
+fi
+if grep -qE '^MISE_REACHABLE = .*-lc' "$MAKEFILE"; then
+  ok "case 7: MISE_REACHABLE still probes under a login shell"
+else
+  bad "case 7: MISE_REACHABLE still probes under a login shell"
+fi
+
 echo "=== Block 2: both writers reach it ==="
 
 update_recipe() {

--- a/scripts/test/ensure_mise_zshrc_lines_test.sh
+++ b/scripts/test/ensure_mise_zshrc_lines_test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# ensure_mise_zshrc_lines_test.sh — tests for the ADD half of the asdf -> mise
+# cutover's ~/.zshrc work (issue #38).
+#
+# The bug this pins: `make update` stripped the asdf/direnv init lines but
+# never added the mise ones, because only shell_setup.sh wrote them and
+# `update` deliberately never runs shell_setup.sh. A host that went through
+# the cutover purely via `make update` ended with mise installed, the old
+# version manager gone, and no version manager wired into the interactive
+# shell — observed on a real host, whose ~/.zshrc had zero `mise` lines until
+# a manual `make shell`.
+#
+# Block 1 (behavioral): the script itself — writes both lines, is idempotent,
+# and holds the activation line back when mise is unreachable.
+#
+# Block 2 (static): BOTH writers reach it. `update`'s recipe calls it, under
+# the same `VM_SKIP` guard as the strip and after it; shell_setup.sh calls it
+# instead of inlining the lines, so the two paths cannot drift.
+#
+# Run: /bin/bash scripts/test/ensure_mise_zshrc_lines_test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SUT="$REPO_ROOT/scripts/ensure_mise_zshrc_lines.sh"
+MAKEFILE="$REPO_ROOT/Makefile"
+
+pass=0
+fail=0
+ok()   { pass=$((pass+1)); printf 'PASS: %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf 'FAIL: %s\n' "$1"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$3', got '$2')"; fi; }
+
+SANDBOX="$REPO_ROOT/.claude/tmp/issue-38-mise-activation"
+rm -rf "$SANDBOX"
+mkdir -p "$SANDBOX"
+
+SHIMS_LINE='mise/shims:$PATH'
+ACTIVATE_LINE='eval "$(mise activate zsh)"'
+
+# A stub that makes `command -v "$MISE"` succeed without a real mise.
+MISE_STUB="$SANDBOX/mise"
+printf '#!/bin/bash\nexit 0\n' > "$MISE_STUB"
+chmod +x "$MISE_STUB"
+
+run_sut() { # $1 = zshrc path, $2 = MISE value
+  OUT="$(ZSHRC_PATH="$1" MISE="$2" /bin/bash "$SUT" 2>&1)"
+  RC=$?
+}
+
+echo "=== Block 1: the script ==="
+
+# === case 1: fresh ~/.zshrc, mise reachable ===========================
+Z="$SANDBOX/case1-zshrc"
+: > "$Z"
+run_sut "$Z" "$MISE_STUB"
+check "case 1: exits zero" "$RC" "0"
+check "case 1: shims PATH export added" "$(grep -cF "$SHIMS_LINE" "$Z")" "1"
+check "case 1: activation line added"   "$(grep -cFx "$ACTIVATE_LINE" "$Z")" "1"
+
+# === case 2: re-run is a no-op (idempotent) ============================
+BEFORE="$(cat "$Z")"
+run_sut "$Z" "$MISE_STUB"
+check "case 2: exits zero" "$RC" "0"
+check "case 2: file unchanged" "$(cat "$Z")" "$BEFORE"
+check "case 2: no duplicate shims line" "$(grep -cF "$SHIMS_LINE" "$Z")" "1"
+check "case 2: no duplicate activation line" "$(grep -cFx "$ACTIVATE_LINE" "$Z")" "1"
+
+# === case 3: mise unreachable -> shims yes, activation no ==============
+Z3="$SANDBOX/case3-zshrc"
+: > "$Z3"
+run_sut "$Z3" "$SANDBOX/definitely-not-a-real-mise"
+check "case 3: exits zero" "$RC" "0"
+check "case 3: shims PATH export still added" "$(grep -cF "$SHIMS_LINE" "$Z3")" "1"
+check "case 3: activation line held back" "$(grep -cFx "$ACTIVATE_LINE" "$Z3")" "0"
+case "$OUT" in *"mise not yet installed"*) ok "case 3: says why" ;;
+  *) bad "case 3: says why (got: $OUT)" ;; esac
+
+# === case 4: an absent ~/.zshrc is created, not errored on =============
+Z4="$SANDBOX/case4-does-not-exist-yet"
+run_sut "$Z4" "$MISE_STUB"
+check "case 4: exits zero" "$RC" "0"
+[ -f "$Z4" ] && ok "case 4: created the file" || bad "case 4: created the file"
+check "case 4: shims PATH export added" "$(grep -cF "$SHIMS_LINE" "$Z4")" "1"
+
+# === case 5: existing content is preserved =============================
+Z5="$SANDBOX/case5-zshrc"
+printf '# my own line\nexport FOO=1\n' > "$Z5"
+run_sut "$Z5" "$MISE_STUB"
+check "case 5: existing comment kept" "$(grep -c 'my own line' "$Z5")" "1"
+check "case 5: existing export kept"  "$(grep -c 'export FOO=1' "$Z5")" "1"
+check "case 5: shims PATH export added" "$(grep -cF "$SHIMS_LINE" "$Z5")" "1"
+
+echo "=== Block 2: both writers reach it ==="
+
+update_recipe() {
+  awk '
+    /^update:/ { inr = 1; next }
+    inr && /^\t/ { print; next }
+    inr { exit }
+  ' "$MAKEFILE"
+}
+RECIPE="$(update_recipe)"
+
+if grep -qF 'ensure_mise_zshrc_lines.sh' <<<"$RECIPE"; then
+  ok "update adds the mise activation lines"
+else
+  bad "update adds the mise activation lines"
+fi
+
+# Guarded on the same VM_SKIP decision as the strip: a run that held the
+# asdf/direnv removal back must not point ~/.zshrc at a mise that is absent.
+GUARD_LINE="$(grep -nF 'VM_SKIP' <<<"$RECIPE" | grep -F 'if [ -z' | head -1 | cut -d: -f1)"
+STRIP_LINE="$(grep -nF 'strip_asdf_zshrc_lines.sh' <<<"$RECIPE" | head -1 | cut -d: -f1)"
+ENSURE_LINE="$(grep -nF 'ensure_mise_zshrc_lines.sh' <<<"$RECIPE" | head -1 | cut -d: -f1)"
+FI_LINE="$(awk 'NR>'"${GUARD_LINE:-0}"' && /^\t*fi; \\$/ { print NR; exit }' <<<"$RECIPE")"
+
+if [ -n "$GUARD_LINE" ] && [ -n "$ENSURE_LINE" ] && [ -n "$FI_LINE" ] \
+  && [ "$GUARD_LINE" -lt "$ENSURE_LINE" ] && [ "$ENSURE_LINE" -lt "$FI_LINE" ]; then
+  ok "the mise-lines call sits inside the VM_SKIP guard"
+else
+  bad "the mise-lines call sits inside the VM_SKIP guard (guard@${GUARD_LINE:-none} ensure@${ENSURE_LINE:-none} fi@${FI_LINE:-none})"
+fi
+
+if [ -n "$STRIP_LINE" ] && [ -n "$ENSURE_LINE" ] && [ "$STRIP_LINE" -lt "$ENSURE_LINE" ]; then
+  ok "the strip runs before the add"
+else
+  bad "the strip runs before the add (strip@${STRIP_LINE:-none} ensure@${ENSURE_LINE:-none})"
+fi
+
+# shell_setup.sh delegates rather than inlining, so the two paths agree.
+SHELL_SETUP="$REPO_ROOT/scripts/shell_setup.sh"
+if grep -qF 'ensure_mise_zshrc_lines.sh' "$SHELL_SETUP"; then
+  ok "shell_setup.sh calls the shared script"
+else
+  bad "shell_setup.sh calls the shared script"
+fi
+if grep -qF 'mise activate zsh' "$SHELL_SETUP"; then
+  bad "shell_setup.sh no longer inlines the activation line"
+else
+  ok "shell_setup.sh no longer inlines the activation line"
+fi
+
+rm -rf "$SANDBOX"
+
+echo
+echo "---"
+echo "pass=$pass fail=$fail"
+if [ "$fail" -eq 0 ]; then
+  echo "All ensure-mise-zshrc-lines tests passed."
+  exit 0
+fi
+echo "Some ensure-mise-zshrc-lines tests FAILED."
+exit 1

--- a/scripts/test/install_cutover_guard_test.sh
+++ b/scripts/test/install_cutover_guard_test.sh
@@ -88,7 +88,10 @@ recipe_of() {
 # Block 1: the guard is defined once and used by both destructive paths.
 # ---------------------------------------------------------------------
 static_test() {
-  ok "$(grep -q '^MISE_REACHABLE *= *bash -lc ' "$MAKEFILE" && echo 0 || echo 1)" \
+  # $(BASH_BIN), not a bare `bash`: the probe runs immediately before the
+  # destructive half of the cutover, on a run that may already have removed
+  # Homebrew's bash formula (issue #37).
+  ok "$(grep -q '^MISE_REACHABLE *= *\$(BASH_BIN) -lc ' "$MAKEFILE" && echo 0 || echo 1)" \
     "MISE_REACHABLE is defined as a shared probe"
   ok "$(grep -q "^MISE_REACHABLE *=.*command -v" "$MAKEFILE" && echo 0 || echo 1)" \
     "MISE_REACHABLE probes for the mise binary"

--- a/scripts/test/update_cutover_order_test.sh
+++ b/scripts/test/update_cutover_order_test.sh
@@ -111,8 +111,17 @@ order_test() {
     "Uninstall loop is handed REMOVE_SKIP_BASENAMES"
   ok_contains "$recipe" '-s remove-and-purge REMOVE_SKIP_BASENAMES=' \
     "RemoveAndPurge loop is handed REMOVE_SKIP_BASENAMES"
-  ok_contains "$recipe" 'if [ -z "$$VM_SKIP" ]; then $(BASH_BIN) scripts/strip_asdf_zshrc_lines.sh' \
-    "the ~/.zshrc strip is guarded on the same skip decision"
+  # The guard opens a block carrying BOTH ~/.zshrc rewrites -- the strip and
+  # the mise-lines add (issue #38) -- so a held-back cutover performs neither.
+  # scripts/test/ensure_mise_zshrc_lines_test.sh pins the containment; here we
+  # pin that the guard is still the same VM_SKIP decision and still precedes
+  # the strip.
+  ok_contains "$recipe" 'if [ -z "$$VM_SKIP" ]; then' \
+    "the ~/.zshrc rewrites are guarded on the same skip decision"
+  ok_before "$recipe" 'if [ -z "$$VM_SKIP" ]; then' 'strip_asdf_zshrc_lines.sh' \
+    "the guard precedes the ~/.zshrc strip"
+  ok_contains "$recipe" '$(BASH_BIN) scripts/strip_asdf_zshrc_lines.sh' \
+    "the strip is invoked through the absolute bash"
 
   # The skip list names slot 04 only.
   ok_contains "$recipe" 'VM_SKIP="$(VM_UNINSTALL) $(VM_PURGE)"' \

--- a/scripts/test/update_cutover_order_test.sh
+++ b/scripts/test/update_cutover_order_test.sh
@@ -111,7 +111,7 @@ order_test() {
     "Uninstall loop is handed REMOVE_SKIP_BASENAMES"
   ok_contains "$recipe" '-s remove-and-purge REMOVE_SKIP_BASENAMES=' \
     "RemoveAndPurge loop is handed REMOVE_SKIP_BASENAMES"
-  ok_contains "$recipe" 'if [ -z "$$VM_SKIP" ]; then bash scripts/strip_asdf_zshrc_lines.sh' \
+  ok_contains "$recipe" 'if [ -z "$$VM_SKIP" ]; then $(BASH_BIN) scripts/strip_asdf_zshrc_lines.sh' \
     "the ~/.zshrc strip is guarded on the same skip decision"
 
   # The skip list names slot 04 only.


### PR DESCRIPTION
## Summary

Two defects on the `make update` asdf -> mise cutover path, both observed on
a real host, both landing on the same `update` recipe lines.

### Recipes resolved bash through PATH (#37)

The slot-04 `RemoveAndPurge` uninstalled `asdf`, and `brew uninstall`'s
automatic `brew autoremove` took Homebrew's `bash` formula with it as an
unneeded dependency. Because the host's PATH prefers `/opt/homebrew/bin`,
every later recipe line that invoked a helper script as `bash scripts/foo.sh`
then died with:

```text
/bin/bash: /opt/homebrew/bin/bash: No such file or directory
```

The casualty that mattered was the `update` target's `~/.zshrc` strip: asdf
and direnv were gone but their init lines stayed, erroring on every shell
startup.

Two independent defenses, because either alone leaves the other hazard open:

- `BASH_BIN := /bin/bash` in the Makefile, with `SHELL := $(BASH_BIN)` so the
  path is stated once, and every bash invocation in the file swept onto it.
  `/bin/bash` ships with macOS and no Homebrew operation can remove it. Every
  script that re-invokes bash itself names `/bin/bash` for the same reason:
  `shell_setup.sh`'s strip and add calls, `claude_repo_setup.sh`'s
  `plugins.sh` call, and `ensure_mise_zshrc_lines.sh`'s `/bin/bash -lc`
  reachability probe.
- `HOMEBREW_NO_AUTOREMOVE=1` exported from `remove_runner.sh` — the one place
  both removal trees actually call brew — so an uninstall never cascades into
  a shared dependency in the first place.

`/bin/bash` is bash 3.2. Every script in `scripts/` is already written to 3.2
(there is an explicit "macOS ships bash 3.2" note in the existing test suite),
every one was re-checked with `bash -n` under 3.2, and a grep for bash-4-only
constructs (`declare -A`, `mapfile`, `${v,,}`, …) found none. No script's
behavior changes.

### The cutover stripped the old init lines but added no new ones (#38)

A host reaching the cutover purely via `make update` — never running
`make install` or `make shell` — ended it with mise installed, asdf and direnv
uninstalled, their `~/.zshrc` init lines stripped, and **no version manager
wired into the interactive shell at all**. The shims PATH export and
`eval "$(mise activate zsh)"` were only ever written by `shell_setup.sh`,
which `update` deliberately does not run.

That write is now `scripts/ensure_mise_zshrc_lines.sh` — the ADD half to
`strip_asdf_zshrc_lines.sh`'s REMOVE half — called by both writers so the two
paths cannot drift: `shell_setup.sh` delegates instead of inlining, and
`update` calls the strip and then the add. Both sit inside the existing
`VM_SKIP` guard, because a run that held the asdf/direnv removal back must not
point `~/.zshrc` at a mise that is not there. The activation line carries its
own `command -v` gate for the same reason; the shims PATH export does not need
one, since a PATH entry naming a directory that does not exist yet is inert.

The `update` target's comment claimed the cutover was "all three pieces of it"
while doing three of four. Corrected, along with the same claim in `CLAUDE.md`,
`docs/MAKEFILE.md`, and `docs/VERSION_MANAGEMENT.md`.

## Testing

Two new test files, and the whole existing suite green:

- `scripts/test/absolute_bash_test.sh` — no PATH-resolved bash survives in the
  Makefile, in `shell_setup.sh`, or in `claude_repo_setup.sh`, `BASH_BIN` is
  the absolute path, `SHELL` derives from it, and `HOMEBREW_NO_AUTOREMOVE=1`
  is exported. The
  bare-bash pattern self-verifies: it is re-run against a deliberately mutated
  Makefile and must fire there.
- `scripts/test/ensure_mise_zshrc_lines_test.sh` — behavioral (both lines
  written, idempotent re-run, activation held back when mise is unreachable,
  absent `~/.zshrc` created, existing content preserved) plus static (both
  writers reach the script; the call sits inside the guard, after the strip).
- All 20 test files under `scripts/test/` pass. The existing assertions that
  pinned the literal `bash ...` recipe text now pin `$(BASH_BIN)`.
- `make -n help` parses; every edited Markdown file passes
  `npx markdownlint-cli2` clean.

Closes #37
Closes #38



