### PR TITLE
Add update_claude_plugins to the claude-code-aliases profile

### DIFF
--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -148,6 +148,30 @@ claude-plugin-path() {
   ' "$db" 2>/dev/null
 }
 
+# Update every marketplace and enabled plugin declared in the global
+# Claude settings.json. A plugin entry in .enabledPlugins is either a
+# boolean or an object with an `enabled` key; the type guard on the
+# object index matters because jq's `or` does not short-circuit the
+# right operand's evaluation errors -- indexing a boolean with
+# .enabled aborts the whole filter (claude-config#44).
+update_claude_plugins() {
+  local settings="${1:-$HOME/.claude/settings.json}"
+  local i
+  local -a marketplaces plugins
+
+  marketplaces=("${(@f)$(jq -r '.extraKnownMarketplaces // {} | keys[]' "$settings")}")
+  for i in "${marketplaces[@]}"; do
+    [[ -n "$i" ]] || continue
+    claude plugin marketplace update "$i"
+  done
+
+  plugins=("${(@f)$(jq -r '.enabledPlugins // {} | to_entries[] | select(.value == true or ((.value | type) == "object" and .value.enabled == true)) | .key' "$settings")}")
+  for i in "${plugins[@]}"; do
+    [[ -n "$i" ]] || continue
+    claude plugin update "$i"
+  done
+}
+
 claude-vm() {
   local root exe
   root=$(claude-plugin-path 'claude-vm@thevoskamps') || {


### PR DESCRIPTION
Ports the host-tier `update_claude_plugins` macro into `profiles/claude-code-aliases/aliases.zsh`, with the jq type guard from TheVoskamps/claude-config#45 so a plain-boolean `false` entry in `.enabledPlugins` is filtered instead of aborting the whole plugin loop with `Cannot index boolean with string ("enabled")` (claude-config#44).

Changes from the host-tier original:

- The jq filter guards the object index: `select(.value == true or ((.value | type) == "object" and .value.enabled == true))`.
- Bash's `mapfile` is replaced with zsh `${(@f)...}` splitting (the profile is sourced by zsh).
- Both jq inputs default with `// {}` and empty elements are skipped, so a settings file missing either key is a clean no-op.

Tested with a stubbed `claude` against a settings fixture carrying all four entry shapes (`true`, `false`, `{enabled: true}`, `{enabled: false}`) — only the two enabled plugins update, no jq error — and against an empty `{}` settings file.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fvnb5zwQWayuGYVZLZB8Sz
