### PR TITLE
Add save_claude_auth / load_claude_auth for multiple Claude accounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ calls are **non-fatal**: if the `claude` CLI is not on PATH, if
 predating the plugins refactor), or if `plugins.sh` exits non-zero,
 the sync prints a warning and is skipped/ignored rather than aborting
 `make install` / `make update` (same posture as the
-`git pull` step). The two standalone targets `claude-plugins-install`
+`git pull` step). The standalone targets `claude-plugins-install`
 / `claude-plugins-update` drive the same code path directly and DO
 surface a `plugins.sh` non-zero exit (the missing-binary /
 missing-script guards still warn-and-skip with success). Both the
@@ -1091,10 +1091,11 @@ former in-repo `logs/` directory. This is macOS-native
     is already installed by the default tier for
     bootstrap). The `cr` Claude-CLI wrapper and its
     `cr-repo` companion live in
-    `profiles/claude-code-aliases/aliases.zsh` — a
-    no-software profile that exists only to carry those
-    functions, opted into alongside a `claude`/`claude-latest`
-    profile. `cr` works from any cwd: when the cwd is inside an
+    `profiles/claude-code-aliases/aliases.zsh` — a profile
+    that exists to carry those functions (its `Brewfile`
+    declares only the `jq` they need), opted into
+    alongside a `claude`/`claude-latest` profile. `cr` works
+    from any cwd: when the cwd is inside an
     existing repo (root OR a subdirectory) it `cd`s to the repo
     root and derives the session name from `origin`; when the cwd
     is outside any repo it `git init`s a throwaway repo, runs
@@ -1109,7 +1110,7 @@ former in-repo `logs/` directory. This is macOS-native
     `Claude Code-credentials`) and the `oauthAccount` block of
     `~/.claude.json` are swapped, backed up per account as
     `Claude Code-credentials-<account>` and the `0400` sidecar
-    `~/.claude.json.<account>`. Two profile kinds: the built-in
+    `~/.claude.json.<account>`. Profile kinds: the built-in
     default (used when `--account` is omitted; the name `default`
     is reserved and can never be typed) and named profiles
     (explicit `--account NAME`, validated against

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1102,7 +1102,23 @@ former in-repo `logs/` directory. This is macOS-native
     function-local trap (EXIT plus INT/TERM) on every return path.
     `cr-repo` is the strict variant: it requires an existing repo
     with an `origin` remote (deriving the session name from it) and
-    errors otherwise.
+    errors otherwise. The same profile carries
+    `save_claude_auth` / `load_claude_auth` for using multiple
+    Claude Code Max accounts on one machine without forking
+    `~/.claude`: only the OAuth token (Keychain item
+    `Claude Code-credentials`) and the `oauthAccount` block of
+    `~/.claude.json` are swapped, backed up per account as
+    `Claude Code-credentials-<account>` and the `0400` sidecar
+    `~/.claude.json.<account>`. Two profile kinds: the built-in
+    default (used when `--account` is omitted; the name `default`
+    is reserved and can never be typed) and named profiles
+    (explicit `--account NAME`, validated against
+    `^[A-Za-z0-9._@-]+$` — `PROFILE_NAME_RE` plus `@`, so an
+    account email works as a name). One live identity at a time:
+    switching while another Claude session runs repoints the
+    credentials underneath it (documented limitation, no
+    locking) — quit running sessions before switching. See
+    `docs/SHELL.md` "Multiple Claude Code accounts".
   - **Per-machine host `aliases.zsh`** — only genuinely
     host-specific entries (e.g. an `icloud` shortcut to a
     machine's iCloud Drive path, or a host-only workspace

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ profiles it opts into.
 
 ## Quick Start (Recommended)
 
-### Step 1: Bootstrap Your Machine
+### Bootstrap Your Machine
 
 Download and run the bootstrap script from any location:
 
@@ -77,7 +77,7 @@ bash ./bootstrap.sh
 > for when you *do* need SSH auth (pushing to this repo,
 > cloning private repos).
 
-### Step 2: Install Everything
+### Install Everything
 
 ```bash
 cd macos-setup
@@ -594,9 +594,10 @@ profiles/
 │                               # uninstall / purge (per-tier), plus any
 │                               # [claude]/[mailer]/[cron] overrides
 │                               # (single-winner per section)
-├── claude-code-aliases/        # A "no-software" profile: mostly an
-│   ├── aliases.zsh             # aliases.zsh (the cr + cr-repo Claude
-│   └── Brewfile                # wrappers) plus the jq those need
+├── claude-code-aliases/        # Mostly an aliases.zsh: the cr +
+│   ├── aliases.zsh             # cr-repo Claude wrappers and the
+│   └── Brewfile                # save/load_claude_auth account
+│                               # switchers, plus the jq those need
 ├── aws/                        # …40 more single-purpose profiles
 └── …                           #   (databases, web, plex, yubikey, …)
 

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -86,10 +86,10 @@ be noticeable.
     variant that requires an existing repo with an `origin` remote and
     errors otherwise). The same profile carries `save_claude_auth` /
     `load_claude_auth` for switching between Claude Code Max accounts
-    (see "Multiple Claude Code accounts" below). A profile may carry an
-    `aliases.zsh` and nothing
-    else (a "no-software" profile such as `claude-code-aliases`, which
-    has no `Brewfile`) — opting into it just contributes its
+    (see "Multiple Claude Code accounts" below). A profile may exist
+    mostly to carry an `aliases.zsh` — `claude-code-aliases` ships
+    only that file plus a `Brewfile` declaring the `jq` its
+    functions parse JSON with; opting into it mainly contributes its
     aliases to the aggregate.
   - **host tier** — only genuinely host-specific entries (e.g. an
     `icloud` shortcut to a machine's iCloud Drive path).
@@ -130,7 +130,7 @@ save_claude_auth [--account NAME] [--force]   # back up the live login
 load_claude_auth [--account NAME] [--force]   # restore a saved login
 ```
 
-There are two kinds of profile:
+The kinds of profile:
 
 - **The built-in default** — used automatically when `--account` is
   omitted, on both save and load. It is stored exactly like any named
@@ -167,9 +167,9 @@ Behavior worth knowing:
   sessions before switching.
 
 Switching accounts is an explicit step before launching Claude — it is
-not a flag on `cr` or the other launchers. `jq` (core tier) and the
-macOS `security` built-in are the only dependencies, so the profile
-stays no-software. Covered by
+not a flag on `cr` or the other launchers. The pair adds no new
+dependency: `jq` is already declared (by the core tier and by this
+profile's own `Brewfile`) and `security` ships with macOS. Covered by
 `scripts/test/save_load_claude_auth_test.zsh`, which stubs `security`
 and points `HOME` at a temp dir so the real Keychain and
 `~/.claude.json` are never touched.

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -114,7 +114,7 @@ macos-setup itself) in `shared/zsh/` instead.
 The `claude-code-aliases` profile carries a pair of functions for using
 more than one Claude Code Max account on a single machine, without
 forking `~/.claude`. Skills, plugins, settings, and session history stay
-shared; only the two pieces that carry account identity get swapped:
+shared; only the pieces that carry account identity get swapped:
 
 - the OAuth token in the macOS Keychain, service
   `Claude Code-credentials`

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -84,7 +84,10 @@ be noticeable.
     `origin`, and outside any repo it `git init`s a throwaway repo and
     tears down only the `.git` it created; `cr-repo` is the strict
     variant that requires an existing repo with an `origin` remote and
-    errors otherwise). A profile may carry an `aliases.zsh` and nothing
+    errors otherwise). The same profile carries `save_claude_auth` /
+    `load_claude_auth` for switching between Claude Code Max accounts
+    (see "Multiple Claude Code accounts" below). A profile may carry an
+    `aliases.zsh` and nothing
     else (a "no-software" profile such as `claude-code-aliases`, which
     has no `Brewfile`) — opting into it just contributes its
     aliases to the aggregate.
@@ -105,6 +108,71 @@ file lives OUTSIDE the repo, so backing it up is your responsibility (the
 default- and profile-tier `aliases.zsh` files remain in the repo and are
 committed normally). Keep system-level helpers (functions used by
 macos-setup itself) in `shared/zsh/` instead.
+
+## Multiple Claude Code accounts (`save_claude_auth` / `load_claude_auth`)
+
+The `claude-code-aliases` profile carries a pair of functions for using
+more than one Claude Code Max account on a single machine, without
+forking `~/.claude`. Skills, plugins, settings, and session history stay
+shared; only the two pieces that carry account identity get swapped:
+
+- the OAuth token in the macOS Keychain, service
+  `Claude Code-credentials`
+- the `oauthAccount` block in `~/.claude.json`
+
+Per-account backups live in the Keychain item
+`Claude Code-credentials-<account>` and the sidecar file
+`~/.claude.json.<account>` (created `0400` — it is only ever read back
+by `load_claude_auth`).
+
+```zsh
+save_claude_auth [--account NAME] [--force]   # back up the live login
+load_claude_auth [--account NAME] [--force]   # restore a saved login
+```
+
+There are two kinds of profile:
+
+- **The built-in default** — used automatically when `--account` is
+  omitted, on both save and load. It is stored exactly like any named
+  profile (suffix `default`), but that name can never be typed:
+  `--account default` is always rejected, so "the implicit one" and "a
+  profile someone explicitly named default" can never be confused.
+- **Named profiles** — anything saved or loaded with an explicit
+  `--account NAME`.
+
+Behavior worth knowing:
+
+- **Names are validated.** A name is both a filename component and a
+  Keychain service suffix, so it must match `^[A-Za-z0-9._@-]+$` (the
+  repo's `PROFILE_NAME_RE` charset plus `@`, so a Claude account email
+  works verbatim as the name). Anything else — including `--account`
+  with no following value, and any unrecognized argument — is rejected
+  by name with a non-zero return.
+- **Save refuses to overwrite** an existing profile (built-in default
+  or named) without `--force`.
+- **Load refuses to clobber an unsaved identity.** Loading overwrites
+  the live Keychain item and `~/.claude.json`; if the identity that was
+  live was never saved, it is gone and that account must be logged into
+  again. Before overwriting, `load_claude_auth` compares the live
+  `oauthAccount` against every `~/.claude.json.*` sidecar (on
+  `.emailAddress` and `.accountUuid`) and aborts when none matches,
+  unless `--force` is passed.
+- **Load with no `--account`** requires that the built-in default has
+  been saved at least once; otherwise it fails loudly rather than
+  silently leaving the current login untouched.
+- **Concurrency is a documented limitation, not a guarded one.** There
+  is one live identity at a time; switching while another Claude
+  session is running repoints the Keychain item and `~/.claude.json`
+  underneath it. No locking is implemented — quit running Claude
+  sessions before switching.
+
+Switching accounts is an explicit step before launching Claude — it is
+not a flag on `cr` or the other launchers. `jq` (core tier) and the
+macOS `security` built-in are the only dependencies, so the profile
+stays no-software. Covered by
+`scripts/test/save_load_claude_auth_test.zsh`, which stubs `security`
+and points `HOME` at a temp dir so the real Keychain and
+`~/.claude.json` are never touched.
 
 ## mise init lines
 

--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -203,7 +203,7 @@ claude-vm() {
 # Multiple Claude Code Max accounts on one machine (issue #49).
 #
 # Skills, plugins, settings and session history stay shared in ~/.claude;
-# only the two pieces that carry account identity get swapped:
+# only the pieces that carry account identity get swapped:
 #   - the OAuth token in the macOS Keychain, service "Claude Code-credentials"
 #   - the .oauthAccount block in ~/.claude.json
 # Per-account backups live in the Keychain item

--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -199,3 +199,176 @@ claude-vm() {
   }
   "$exe" "$@"
 }
+
+# Multiple Claude Code Max accounts on one machine (issue #49).
+#
+# Skills, plugins, settings and session history stay shared in ~/.claude;
+# only the two pieces that carry account identity get swapped:
+#   - the OAuth token in the macOS Keychain, service "Claude Code-credentials"
+#   - the .oauthAccount block in ~/.claude.json
+# Per-account backups live in the Keychain item
+# "Claude Code-credentials-<account>" and the sidecar file
+# ~/.claude.json.<account> (created 0400 -- only ever read back).
+#
+# Two kinds of profile: the BUILT-IN DEFAULT (used when --account is
+# omitted, stored under the suffix "default") and NAMED profiles
+# (explicit --account NAME). The name "default" can never be typed --
+# `--account default` is always rejected -- so the implicit profile and
+# an explicitly-named one can never be confused. Account names must
+# match ^[A-Za-z0-9._@-]+$ (the repo's PROFILE_NAME_RE charset plus @,
+# so an account email works verbatim as the name).
+#
+# CONCURRENCY LIMITATION (documented, not guarded): there is one live
+# identity at a time. Switching while another Claude session is running
+# repoints the Keychain item and ~/.claude.json underneath it. No
+# locking is implemented -- quit running Claude sessions before
+# switching. See docs/SHELL.md.
+
+save_claude_auth () {
+    local account="default" pw oauth explicit=0 force=0
+
+    while (( $# )); do
+        if [[ "$1" == "--account" ]]; then
+            if (( $# < 2 )); then
+                echo "save_claude_auth: --account requires a value" >&2
+                return 1
+            fi
+            account="$2"
+            explicit=1
+            shift 2
+        elif [[ "$1" == "--force" ]]; then
+            force=1
+            shift
+        else
+            echo "save_claude_auth: unknown argument: $1" >&2
+            return 1
+        fi
+    done
+
+    if (( explicit )); then
+        if [[ "$account" == "default" ]]; then
+            echo "save_claude_auth: 'default' cannot be specified explicitly -- omit --account to use the built-in default" >&2
+            return 1
+        fi
+        if [[ ! "$account" =~ '^[A-Za-z0-9._@-]+$' ]]; then
+            echo "save_claude_auth: invalid account name '${account}' -- allowed characters are A-Z a-z 0-9 . _ @ -" >&2
+            return 1
+        fi
+    fi
+
+    if [[ -f ~/.claude.json."${account}" ]] && (( ! force )); then
+        if [[ "$account" == "default" ]]; then
+            echo "save_claude_auth: the built-in default already has a saved account -- pass --force to overwrite it" >&2
+        else
+            echo "save_claude_auth: '${account}' already has a saved account -- pass --force to overwrite it" >&2
+        fi
+        return 1
+    fi
+
+    pw=$(security find-generic-password -s "Claude Code-credentials" -a "$USER" -w) || {
+        echo "save_claude_auth: not currently logged in" >&2
+        return 1
+    }
+
+    oauth=$(jq '.oauthAccount' ~/.claude.json 2>/dev/null)
+    if [[ -z "$oauth" || "$oauth" == "null" ]]; then
+        echo "save_claude_auth: no oauthAccount in ~/.claude.json -- not currently logged in" >&2
+        unset pw
+        return 1
+    fi
+
+    security add-generic-password -U -s "Claude Code-credentials-${account}" -a "$USER" -w "$pw" >/dev/null
+    unset pw
+
+    # The sidecar is created 0400 (read-only for the owner: it is only
+    # ever read back by load_claude_auth), so a --force overwrite must
+    # remove the old one before writing. `command rm` bypasses the
+    # `rm -i` safety alias from default/aliases.zsh.
+    command rm -f ~/.claude.json."${account}"
+    jq -n --argjson oauth "$oauth" '{oauthAccount: $oauth}' > ~/.claude.json."${account}"
+    chmod 0400 ~/.claude.json."${account}"
+    echo "save_claude_auth: saved '${account}'" >&2
+}
+
+load_claude_auth () {
+    local account="default" pw oauth tmp live sidecar explicit=0 force=0 matched=0
+
+    while (( $# )); do
+        if [[ "$1" == "--account" ]]; then
+            if (( $# < 2 )); then
+                echo "load_claude_auth: --account requires a value" >&2
+                return 1
+            fi
+            account="$2"
+            explicit=1
+            shift 2
+        elif [[ "$1" == "--force" ]]; then
+            force=1
+            shift
+        else
+            echo "load_claude_auth: unknown argument: $1" >&2
+            return 1
+        fi
+    done
+
+    if (( explicit )); then
+        if [[ "$account" == "default" ]]; then
+            echo "load_claude_auth: 'default' cannot be specified explicitly -- omit --account to use the built-in default" >&2
+            return 1
+        fi
+        if [[ ! "$account" =~ '^[A-Za-z0-9._@-]+$' ]]; then
+            echo "load_claude_auth: invalid account name '${account}' -- allowed characters are A-Z a-z 0-9 . _ @ -" >&2
+            return 1
+        fi
+    fi
+
+    [[ -f ~/.claude.json."${account}" ]] || {
+        if [[ "$account" == "default" ]]; then
+            echo "load_claude_auth: no built-in default saved yet -- run save_claude_auth (no --account) while logged into it" >&2
+        else
+            echo "load_claude_auth: no saved account '${account}' -- run save_claude_auth --account ${account} first" >&2
+        fi
+        return 1
+    }
+
+    # Refuse to clobber an unsaved identity: loading overwrites the live
+    # Keychain item and ~/.claude.json, and if the identity that was
+    # live was never saved it is gone (that account must be logged into
+    # again). Compare the live oauthAccount against every sidecar on
+    # .emailAddress and .accountUuid; abort unless one matches or
+    # --force is passed.
+    if (( ! force )); then
+        live=$(jq -c '.oauthAccount // empty' ~/.claude.json 2>/dev/null)
+        if [[ -n "$live" && "$live" != "null" ]]; then
+            for sidecar in ~/.claude.json.*(N); do
+                if jq -e --argjson live "$live" \
+                    '.oauthAccount as $s
+                     | $s.emailAddress == $live.emailAddress
+                       and $s.accountUuid == $live.accountUuid' \
+                    "$sidecar" >/dev/null 2>&1; then
+                    matched=1
+                    break
+                fi
+            done
+            if (( ! matched )); then
+                echo "load_claude_auth: the current login was never saved and would be lost -- run save_claude_auth first, or pass --force to discard it" >&2
+                return 1
+            fi
+        fi
+    fi
+
+    pw=$(security find-generic-password -s "Claude Code-credentials-${account}" -a "$USER" -w 2>/dev/null) || {
+        echo "load_claude_auth: no Keychain entry for '${account}'" >&2
+        return 1
+    }
+    security add-generic-password -U -s "Claude Code-credentials" -a "$USER" -w "$pw" >/dev/null
+    unset pw
+
+    oauth=$(jq '.oauthAccount' ~/.claude.json."${account}")
+    tmp=$(mktemp)
+    # `command mv -f` bypasses the `mv -i` safety alias that
+    # default/aliases.zsh defines for every host, which would prompt.
+    jq --argjson oauth "$oauth" '.oauthAccount = $oauth' ~/.claude.json > "$tmp" \
+        && command mv -f "$tmp" ~/.claude.json
+    echo "load_claude_auth: switched to '${account}'" >&2
+}

--- a/profiles/claude-code-aliases/aliases.zsh
+++ b/profiles/claude-code-aliases/aliases.zsh
@@ -277,7 +277,14 @@ save_claude_auth () {
         return 1
     fi
 
-    security add-generic-password -U -s "Claude Code-credentials-${account}" -a "$USER" -w "$pw" >/dev/null
+    # The Keychain backup is written before the sidecar, and each write
+    # is checked: a failed write reports the state it actually left
+    # behind and returns non-zero, never the "saved" message.
+    if ! security add-generic-password -U -s "Claude Code-credentials-${account}" -a "$USER" -w "$pw" >/dev/null; then
+        unset pw
+        echo "save_claude_auth: writing the Keychain backup for '${account}' FAILED -- nothing was saved (no Keychain backup, no sidecar)" >&2
+        return 1
+    fi
     unset pw
 
     # The sidecar is created 0400 (read-only for the owner: it is only
@@ -285,7 +292,10 @@ save_claude_auth () {
     # remove the old one before writing. `command rm` bypasses the
     # `rm -i` safety alias from default/aliases.zsh.
     command rm -f ~/.claude.json."${account}"
-    jq -n --argjson oauth "$oauth" '{oauthAccount: $oauth}' > ~/.claude.json."${account}"
+    if ! jq -n --argjson oauth "$oauth" '{oauthAccount: $oauth}' > ~/.claude.json."${account}"; then
+        echo "save_claude_auth: writing the sidecar ~/.claude.json.${account} FAILED -- the Keychain backup for '${account}' was written but the sidecar is missing or incomplete, so load_claude_auth will not accept this profile; re-run save_claude_auth with --force" >&2
+        return 1
+    fi
     chmod 0400 ~/.claude.json."${account}"
     echo "save_claude_auth: saved '${account}'" >&2
 }
@@ -357,18 +367,56 @@ load_claude_auth () {
         fi
     fi
 
+    # Validate every source the swap depends on BEFORE changing
+    # anything, so a bad input means "refused, nothing changed" rather
+    # than a half-applied switch that leaves the Keychain and
+    # ~/.claude.json naming different accounts. There is deliberately
+    # no unwind past the first write: a write that fails anyway
+    # reports the state it actually left behind and returns non-zero.
     pw=$(security find-generic-password -s "Claude Code-credentials-${account}" -a "$USER" -w 2>/dev/null) || {
         echo "load_claude_auth: no Keychain entry for '${account}'" >&2
         return 1
     }
-    security add-generic-password -U -s "Claude Code-credentials" -a "$USER" -w "$pw" >/dev/null
+
+    oauth=$(jq '.oauthAccount' ~/.claude.json."${account}" 2>/dev/null)
+    if [[ -z "$oauth" || "$oauth" == "null" ]]; then
+        echo "load_claude_auth: sidecar ~/.claude.json.${account} is unreadable or carries no oauthAccount -- nothing changed" >&2
+        unset pw
+        return 1
+    fi
+
+    # Build the rewritten ~/.claude.json first, while everything is
+    # still untouched. The temp file lives next to its destination
+    # (inside $HOME, so the test sandbox contains it and the mv below
+    # stays on one filesystem); its name does not match the
+    # ~/.claude.json.* sidecar pattern, so a leftover can never be
+    # mistaken for a saved profile.
+    tmp=$(mktemp ~/.claude.json-new.XXXXXX) || {
+        echo "load_claude_auth: cannot create a temp file under \$HOME -- nothing changed" >&2
+        unset pw
+        return 1
+    }
+    if ! jq --argjson oauth "$oauth" '.oauthAccount = $oauth' ~/.claude.json > "$tmp"; then
+        echo "load_claude_auth: cannot rewrite ~/.claude.json (is it valid JSON?) -- nothing changed" >&2
+        command rm -f "$tmp"
+        unset pw
+        return 1
+    fi
+
+    if ! security add-generic-password -U -s "Claude Code-credentials" -a "$USER" -w "$pw" >/dev/null; then
+        echo "load_claude_auth: writing the live Keychain item FAILED -- the Keychain and ~/.claude.json are both unchanged (still the previous account)" >&2
+        command rm -f "$tmp"
+        unset pw
+        return 1
+    fi
     unset pw
 
-    oauth=$(jq '.oauthAccount' ~/.claude.json."${account}")
-    tmp=$(mktemp)
     # `command mv -f` bypasses the `mv -i` safety alias that
     # default/aliases.zsh defines for every host, which would prompt.
-    jq --argjson oauth "$oauth" '.oauthAccount = $oauth' ~/.claude.json > "$tmp" \
-        && command mv -f "$tmp" ~/.claude.json
+    if ! command mv -f "$tmp" ~/.claude.json; then
+        echo "load_claude_auth: the Keychain now holds '${account}' but rewriting ~/.claude.json FAILED -- the two halves name different accounts; re-run load_claude_auth for '${account}'" >&2
+        command rm -f "$tmp"
+        return 1
+    fi
     echo "load_claude_auth: switched to '${account}'" >&2
 }

--- a/scripts/test/save_load_claude_auth_test.zsh
+++ b/scripts/test/save_load_claude_auth_test.zsh
@@ -3,7 +3,7 @@
 # Functional tests for save_claude_auth / load_claude_auth (issue #49).
 #
 # The pair lives in profiles/claude-code-aliases/aliases.zsh. They swap
-# the two pieces of Claude Code account identity -- the Keychain item
+# the pieces of Claude Code account identity -- the Keychain item
 # "Claude Code-credentials" and the .oauthAccount block of ~/.claude.json
 # -- to and from per-account backups ("Claude Code-credentials-<account>"
 # and ~/.claude.json.<account>).

--- a/scripts/test/save_load_claude_auth_test.zsh
+++ b/scripts/test/save_load_claude_auth_test.zsh
@@ -1,0 +1,294 @@
+#!/usr/bin/env zsh
+
+# Functional tests for save_claude_auth / load_claude_auth (issue #49).
+#
+# The pair lives in profiles/claude-code-aliases/aliases.zsh. They swap
+# the two pieces of Claude Code account identity -- the Keychain item
+# "Claude Code-credentials" and the .oauthAccount block of ~/.claude.json
+# -- to and from per-account backups ("Claude Code-credentials-<account>"
+# and ~/.claude.json.<account>).
+#
+# In the style of cr_test.zsh (real git, stubbed claude), these tests use
+# the REAL jq binary and a stubbed `security` function backed by a plain
+# directory of files (one file per Keychain service name), so the real
+# login Keychain is never touched. HOME is pointed at a per-case temp dir
+# so ~/.claude.json and its sidecars land there, never in the real home.
+#
+# Each case runs in a `( ... )` subshell so the HOME override and the
+# stub never leak into the next case.
+
+emulate -L zsh
+set -u
+
+SCRIPT_DIR="${0:A:h}"
+REPO_ROOT="${SCRIPT_DIR:h:h}"
+PROFILE="$REPO_ROOT/profiles/claude-code-aliases/aliases.zsh"
+
+if [[ ! -r "$PROFILE" ]]; then
+    print -- "FAIL: cannot read $PROFILE" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    print -- "FAIL: jq not on PATH (core-tier dependency)" >&2
+    exit 1
+fi
+
+# Unlike cr_test.zsh, the assertions here run INSIDE the per-case
+# subshells (they need the case's HOME/SEC_DIR), so plain counter
+# variables would not propagate back. pass/die record marker files in a
+# parent-owned dir instead, and the parent counts those at the end.
+COUNT_DIR="$(mktemp -d)"
+trap 'rm -rf "$COUNT_DIR"' EXIT
+pass () { print -- "PASS: $1"; mktemp "$COUNT_DIR/pass.XXXXXX" >/dev/null }
+die  () { print -- "FAIL: $1"; mktemp "$COUNT_DIR/fail.XXXXXX" >/dev/null }
+
+# --- The security stub. Defined as a string and eval'd inside each
+#     subshell (after sourcing the profile) so every case gets it.
+#     State: one file per service name under $SEC_DIR. find with no
+#     matching file returns 44, security's real "not found" status.
+SECURITY_STUB='
+security () {
+    local cmd="$1"; shift
+    local svc="" pwval=""
+    while (( $# )); do
+        case "$1" in
+            -s) svc="$2"; shift 2 ;;
+            -a) shift 2 ;;
+            -w) if (( $# > 1 )); then pwval="$2"; shift 2; else shift; fi ;;
+            -U) shift ;;
+            *)  shift ;;
+        esac
+    done
+    case "$cmd" in
+        find-generic-password)
+            [[ -f "$SEC_DIR/$svc" ]] || return 44
+            cat "$SEC_DIR/$svc"
+            ;;
+        add-generic-password)
+            print -r -- "$pwval" > "$SEC_DIR/$svc"
+            ;;
+        *) return 1 ;;
+    esac
+}
+'
+
+# Seed a "logged in" state for account $1 (email) $2 (uuid) $3 (token).
+seed_login () {
+    print -r -- "$3" > "$SEC_DIR/Claude Code-credentials"
+    jq -n --arg e "$1" --arg u "$2" \
+        '{numStartups: 7, oauthAccount: {emailAddress: $e, accountUuid: $u}}' \
+        > "$HOME/.claude.json"
+}
+
+new_case () {
+    # Usage: eval "$(new_case)" inside a subshell: sets HOME + SEC_DIR.
+    print 'export HOME="$(mktemp -d)"; export SEC_DIR="$HOME/sec"; mkdir -p "$SEC_DIR"'
+}
+
+# --- Test 1: save with no --account saves the built-in default:
+#     Keychain backup + 0400 sidecar. -------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    if ! save_claude_auth 2>/dev/null; then
+        die "save default: returned non-zero"
+    elif [[ "$(cat "$SEC_DIR/Claude Code-credentials-default" 2>/dev/null)" != "tok-a" ]]; then
+        die "save default: Keychain backup missing or wrong"
+    elif [[ "$(jq -r '.oauthAccount.emailAddress' "$HOME/.claude.json.default" 2>/dev/null)" != "a@x.com" ]]; then
+        die "save default: sidecar missing or wrong"
+    elif [[ "$(stat -f '%Lp' "$HOME/.claude.json.default")" != "400" ]]; then
+        die "save default: sidecar not 0400"
+    else
+        pass "save with no --account saves the built-in default (Keychain + 0400 sidecar)"
+    fi
+)
+
+# --- Test 2: --account default rejected on both save and load. -----------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    if save_claude_auth --account default 2>/dev/null; then
+        die "save --account default: was accepted"
+    elif load_claude_auth --account default 2>/dev/null; then
+        die "load --account default: was accepted"
+    else
+        pass "--account default rejected on both save and load"
+    fi
+)
+
+# --- Test 3: save refuses to overwrite without --force (default and
+#     named), and --force overwrites. -------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    save_claude_auth 2>/dev/null
+    save_claude_auth --account work 2>/dev/null
+    if save_claude_auth 2>/dev/null; then
+        die "save default overwrite: no --force but succeeded"
+    elif save_claude_auth --account work 2>/dev/null; then
+        die "save named overwrite: no --force but succeeded"
+    else
+        pass "save refuses to overwrite an existing profile without --force"
+    fi
+    seed_login b@x.com uuid-b tok-b
+    if save_claude_auth --account work --force 2>/dev/null \
+        && [[ "$(cat "$SEC_DIR/Claude Code-credentials-work")" == "tok-b" ]] \
+        && [[ "$(jq -r '.oauthAccount.accountUuid' "$HOME/.claude.json.work")" == "uuid-b" ]]; then
+        pass "save --force overwrites an existing profile (both halves)"
+    else
+        die "save --force: overwrite failed"
+    fi
+)
+
+# --- Test 4: save fails clearly when not logged in. ----------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    err="$(save_claude_auth 2>&1)"
+    if [[ $? -ne 0 && "$err" == *"not currently logged in"* ]]; then
+        pass "save fails clearly when not logged in (no Keychain item)"
+    else
+        die "save when not logged in: expected failure naming the cause"
+    fi
+)
+
+# --- Test 5: load with no --account fails loudly when the built-in
+#     default has never been saved. ---------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    err="$(load_claude_auth 2>&1)"
+    if [[ $? -ne 0 && "$err" == *"no built-in default saved yet"* ]]; then
+        pass "load with no --account fails loudly when default never saved"
+    else
+        die "load with unsaved default: expected loud failure"
+    fi
+)
+
+# --- Test 6: round trip -- save two accounts, load each back; both
+#     halves restored, unrelated ~/.claude.json keys preserved. -----------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    save_claude_auth 2>/dev/null
+    seed_login b@x.com uuid-b tok-b
+    save_claude_auth --account work 2>/dev/null
+    load_claude_auth 2>/dev/null   # back to the built-in default
+    if [[ "$(cat "$SEC_DIR/Claude Code-credentials")" == "tok-a" ]] \
+        && [[ "$(jq -r '.oauthAccount.emailAddress' "$HOME/.claude.json")" == "a@x.com" ]] \
+        && [[ "$(jq -r '.numStartups' "$HOME/.claude.json")" == "7" ]]; then
+        pass "load restores both halves and preserves unrelated ~/.claude.json keys"
+    else
+        die "load round trip: wrong token, oauthAccount, or clobbered keys"
+    fi
+    load_claude_auth --account work 2>/dev/null
+    if [[ "$(cat "$SEC_DIR/Claude Code-credentials")" == "tok-b" ]] \
+        && [[ "$(jq -r '.oauthAccount.accountUuid' "$HOME/.claude.json")" == "uuid-b" ]]; then
+        pass "load --account <name> restores a named profile"
+    else
+        die "load named: both halves not restored"
+    fi
+)
+
+# --- Test 7: load fails clearly when the sidecar or the Keychain entry
+#     is missing. ---------------------------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    err="$(load_claude_auth --account nosuch 2>&1)"
+    if [[ $? -ne 0 && "$err" == *"no saved account 'nosuch'"* ]]; then
+        pass "load names the missing sidecar"
+    else
+        die "load with missing sidecar: expected clear failure"
+    fi
+    save_claude_auth --account work 2>/dev/null
+    command rm -f "$SEC_DIR/Claude Code-credentials-work"
+    err="$(load_claude_auth --account work 2>&1)"
+    if [[ $? -ne 0 && "$err" == *"no Keychain entry for 'work'"* ]]; then
+        pass "load names the missing Keychain entry"
+    else
+        die "load with missing Keychain entry: expected clear failure"
+    fi
+)
+
+# --- Test 8: name validation -- bad charset rejected, email accepted,
+#     --account with no value rejected. -----------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    if save_claude_auth --account 'bad/name' 2>/dev/null; then
+        die "name validation: 'bad/name' accepted on save"
+    elif load_claude_auth --account 'bad name' 2>/dev/null; then
+        die "name validation: 'bad name' accepted on load"
+    else
+        pass "names outside ^[A-Za-z0-9._@-]+\$ are rejected"
+    fi
+    if save_claude_auth --account 'me+work@example.com' 2>/dev/null; then
+        die "name validation: '+' accepted (outside the charset)"
+    else
+        pass "a name with a character outside the charset (+) is rejected"
+    fi
+    if save_claude_auth --account 'me.work@example.com' 2>/dev/null \
+        && [[ -f "$HOME/.claude.json.me.work@example.com" ]]; then
+        pass "an account email works verbatim as the name"
+    else
+        die "name validation: plain email rejected"
+    fi
+    if save_claude_auth --account 2>/dev/null; then
+        die "--account with no value accepted on save"
+    elif load_claude_auth --account 2>/dev/null; then
+        die "--account with no value accepted on load"
+    else
+        pass "--account with no following value is rejected"
+    fi
+)
+
+# --- Test 9: unknown arguments rejected by name, non-zero. ---------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    err="$(save_claude_auth --acount work 2>&1)"
+    rc=$?
+    err2="$(load_claude_auth extra 2>&1)"
+    rc2=$?
+    if (( rc != 0 && rc2 != 0 )) \
+        && [[ "$err" == *"unknown argument: --acount"* ]] \
+        && [[ "$err2" == *"unknown argument: extra"* ]]; then
+        pass "unknown arguments are rejected by name with non-zero status"
+    else
+        die "unknown-argument rejection wrong"
+    fi
+)
+
+# --- Test 10: load refuses to clobber an unsaved live identity, and
+#     proceeds with --force. ----------------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    save_claude_auth --account work 2>/dev/null
+    seed_login c@x.com uuid-c tok-c      # live identity never saved
+    err="$(load_claude_auth --account work 2>&1)"
+    if [[ $? -ne 0 && "$err" == *"never saved"* \
+        && "$(cat "$SEC_DIR/Claude Code-credentials")" == "tok-c" ]]; then
+        pass "load aborts when the live identity matches no sidecar"
+    else
+        die "load did not protect the unsaved live identity"
+    fi
+    if load_claude_auth --account work --force 2>/dev/null \
+        && [[ "$(cat "$SEC_DIR/Claude Code-credentials")" == "tok-a" ]]; then
+        pass "load --force discards the unsaved identity and proceeds"
+    else
+        die "load --force did not proceed"
+    fi
+)
+
+pass=( "$COUNT_DIR"/pass.*(N) )
+fail=( "$COUNT_DIR"/fail.*(N) )
+print
+print -- "---"
+print -- "pass=${#pass} fail=${#fail}"
+if (( ${#fail} == 0 && ${#pass} > 0 )); then
+    print -- "All save/load_claude_auth tests passed."
+    exit 0
+fi
+print -- "Some save/load_claude_auth tests FAILED."
+exit 1

--- a/scripts/test/save_load_claude_auth_test.zsh
+++ b/scripts/test/save_load_claude_auth_test.zsh
@@ -281,6 +281,81 @@ new_case () {
     fi
 )
 
+# --- Test 11: a failed Keychain backup write makes save fail loudly
+#     with nothing saved -- no sidecar, no "saved" message. ---------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    functions[security_orig]=$functions[security]
+    security () {
+        [[ "$1" == "add-generic-password" ]] && return 1
+        security_orig "$@"
+    }
+    seed_login a@x.com uuid-a tok-a
+    err="$(save_claude_auth --account work 2>&1)"
+    if [[ $? -ne 0 && "$err" == *"FAILED"* && "$err" != *"saved 'work'"* \
+        && ! -e "$HOME/.claude.json.work" ]]; then
+        pass "save fails loudly on a Keychain write failure, writing no sidecar"
+    else
+        die "save with a failing Keychain write did not fail loudly with nothing saved"
+    fi
+)
+
+# --- Test 12: load with a corrupt ~/.claude.json refuses up front --
+#     nothing changed: Keychain untouched, JSON untouched, no temp
+#     leftover under $HOME. ------------------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    seed_login a@x.com uuid-a tok-a
+    save_claude_auth --account work 2>/dev/null
+    print -- "not json" > "$HOME/.claude.json"
+    err="$(load_claude_auth --account work 2>&1)"
+    rc=$?
+    leftovers=( "$HOME"/.claude.json-new.*(N) )
+    if [[ $rc -ne 0 && "$err" == *"nothing changed"* \
+        && "$err" != *"switched to"* \
+        && "$(cat "$SEC_DIR/Claude Code-credentials")" == "tok-a" \
+        && "$(cat "$HOME/.claude.json")" == "not json" ]] \
+        && (( ${#leftovers} == 0 )); then
+        pass "load refuses a corrupt ~/.claude.json with nothing changed"
+    else
+        die "load with corrupt ~/.claude.json did not refuse cleanly"
+    fi
+)
+
+# --- Test 13: a failed live-Keychain write makes load fail loudly,
+#     leaving both halves unchanged. ---------------------------------------
+(
+    eval "$(new_case)"; source "$PROFILE"; eval "$SECURITY_STUB"
+    functions[security_orig]=$functions[security]
+    security () {
+        if [[ "$1" == "add-generic-password" ]]; then
+            local -i i
+            for (( i = 2; i <= $#; i++ )); do
+                if [[ "${@[i]}" == "-s" && "${@[i+1]}" == "Claude Code-credentials" ]]; then
+                    return 1
+                fi
+            done
+        fi
+        security_orig "$@"
+    }
+    seed_login a@x.com uuid-a tok-a
+    save_claude_auth --account work 2>/dev/null
+    seed_login b@x.com uuid-b tok-b
+    save_claude_auth --account other 2>/dev/null
+    err="$(load_claude_auth --account work 2>&1)"
+    rc=$?
+    leftovers=( "$HOME"/.claude.json-new.*(N) )
+    if [[ $rc -ne 0 && "$err" == *"both unchanged"* \
+        && "$err" != *"switched to"* \
+        && "$(cat "$SEC_DIR/Claude Code-credentials")" == "tok-b" \
+        && "$(jq -r '.oauthAccount.emailAddress' "$HOME/.claude.json")" == "b@x.com" ]] \
+        && (( ${#leftovers} == 0 )); then
+        pass "load fails loudly on a live-Keychain write failure, both halves unchanged"
+    else
+        die "load with a failing live-Keychain write did not fail cleanly"
+    fi
+)
+
 pass=( "$COUNT_DIR"/pass.*(N) )
 fail=( "$COUNT_DIR"/fail.*(N) )
 print


### PR DESCRIPTION
## Summary

Support more than one Claude Code Max account on a single machine without forking `~/.claude`. Skills, plugins, settings, and session history stay shared; only the two identity-carrying pieces get swapped: the OAuth token in the Keychain item `Claude Code-credentials` and the `oauthAccount` block of `~/.claude.json`. Per-account backups live in the Keychain item `Claude Code-credentials-<account>` and the `0400` sidecar `~/.claude.json.<account>`.

## What changed

- `profiles/claude-code-aliases/aliases.zsh`: new `save_claude_auth` / `load_claude_auth` functions. The built-in default profile is used when `--account` is omitted; the name `default` can never be typed (`--account default` is rejected on both save and load). Names are validated against `^[A-Za-z0-9._@-]+$` (the repo's `PROFILE_NAME_RE` charset plus `@`, so an account email works verbatim); a valueless `--account` and any unrecognized argument are rejected by name with a non-zero return. Save refuses to overwrite an existing profile without `--force`. Load refuses to clobber a live identity that matches no saved sidecar (compared on `.emailAddress` and `.accountUuid`) unless `--force`, and fails loudly when the requested sidecar or Keychain entry is missing. Sidecars are created `0400`; the `--force` overwrite path removes the read-only sidecar before rewriting it. `command rm`/`command mv` bypass the `-i` safety aliases from `default/aliases.zsh`. Concurrency (one live identity at a time) is a documented limitation in the function header and docs, not a guard.
- `scripts/test/save_load_claude_auth_test.zsh`: functional tests in the style of `cr_test.zsh` (which uses real git and a stubbed `claude`): a stubbed `security` function backed by a directory of per-service files, the real `jq`, and `HOME` pointed at a per-case temp dir so the real Keychain and `~/.claude.json` are never touched. Covers every acceptance item: default save/load, the reserved name, overwrite refusal and `--force`, not-logged-in failure, missing sidecar/Keychain failures, name validation (including an email as a name and a rejected `+`), valueless `--account`, unknown-argument rejection, the unsaved-identity guard and its `--force`, sidecar mode `0400`, and preservation of unrelated `~/.claude.json` keys on load.
- `docs/SHELL.md` and `CLAUDE.md`: document the pair — the two profile kinds, the reserved `default` name, the accepted name charset, the storage locations, and the one-live-identity concurrency limitation.

## Why

Switching accounts is an explicit step before launching Claude, not a flag on `cr` or the other launchers, which are untouched. `jq` is already in the core tier and `security` is a macOS built-in, so the profile stays no-software. Passing the token as an argv element to `security add-generic-password` is accepted by design per the issue ("Accepted, not to be re-raised").

## Testing

All test scripts under `scripts/test/` pass, including the new `save_load_claude_auth_test.zsh` (17 assertions). The touched Markdown files pass `markdownlint-cli2` with zero issues.

Closes #49
