### PR TITLE
Correct mise-cutover mechanism claims; drop the inert LuaRocks pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -922,26 +922,6 @@ bespoke `filter` / `filter_exclude` DSL
 (`java = "temurin"` selects the newest Temurin JDK; jre
 builds are named `temurin-jre-*` and are not selected).
 
-**The LuaRocks pin.** LuaRocks 3.13.0 ships a rockspec
-with a duplicate `tag` key. Under asdf's lua plugin that
-broke the build, so this repo pinned 3.12.2 via
-`ASDF_LUA_LUAROCKS_VERSION` -- the variable name that
-plugin reads. `scripts/versions_setup.sh` still exports
-`ASDF_LUA_LUAROCKS_VERSION=3.12.2` so every
-`make versions-*` invocation carries it. On mise it is
-currently INERT: verified against mise 2026.8.6 on
-2026-08-16, `mise registry` resolves `lua` through
-`vfox:mise-plugins/vfox-lua` first, not the asdf plugin,
-and a sandboxed `mise install lua@5.4` built 5.4.8 and
-bootstrapped LuaRocks 3.13.0 successfully with the
-export set. It is kept because it costs nothing and
-still applies to an explicit asdf-backend pin, where the
-breakage is unchanged -- upstream
-`luarocks/luarocks#1851` was closed by a fix to the
-release tooling, and the shipped 3.13.0 tarball is
-PGP-signed with a pinned `source_digest` and was never
-re-rolled. Tracked in issue #6.
-
 **`make asdf-to-mise`** is the one-shot migration verb
 and a deliberate exception to the
 implementation-neutral naming (it names both endpoints

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,16 @@ VM_OPTED_IN := $(filter $(VM_PROFILE),$(PROFILES))
 # It is a macro, not two hand-written `command -v` calls, so the two
 # paths cannot drift and neither can lose the guard silently.
 #
-# `$(BASH_BIN) -lc` because a mise installed moments earlier in the same run
-# lands on a login shell's PATH, not necessarily on make's. `$${MISE:-mise}`
+# The probe sees the PATH it inherits from the invoking shell, plus
+# whatever a bash login shell's startup files (`/etc/profile`, then the
+# first of `~/.bash_profile` / `~/.bash_login` / `~/.profile`) add — a
+# bash login shell never reads `~/.zprofile`, which is where bootstrap.sh
+# writes the Homebrew shellenv line on a stock-zsh host that already has
+# one. So a mise installed in the same shell session as that bootstrap
+# run is NOT covered: the probe can report it unreachable and hold the
+# cutover back (fail-safe — the removal is skipped, never mis-run). The
+# common case works because the invoking shell already has Homebrew on
+# PATH and `-lc` inherits it. `$${MISE:-mise}`
 # honors the same override scripts/mise_common.sh reads, which is also
 # what lets scripts/test/install_cutover_guard_test.sh point it at an
 # absent binary.

--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ nothing, untracking nothing, and committing nothing.
 See
 [docs/VERSION_MANAGEMENT.md](docs/VERSION_MANAGEMENT.md)
 for the full runbook, the multi-version-line pre-flight,
-the LuaRocks pin, and the manual cleanup checklist.
+and the manual cleanup checklist.
 
 ### Workspace Management (Multi-Monitor Setup)
 

--- a/docs/SHELL.md
+++ b/docs/SHELL.md
@@ -193,15 +193,23 @@ it is correct the moment mise lands.
 
 "On `PATH`" is decided in two steps: the calling shell's `PATH` first,
 then a fallback to `/bin/bash -lc` — which is exactly what the
-Makefile's `MISE_REACHABLE` macro is. The login-shell half matters
-because a
-mise installed moments earlier in the same run lands on a login shell's
-`PATH`, not necessarily on make's — and `MISE_REACHABLE` is what lets
-`make update` remove asdf and direnv. If this script checked only make's
-`PATH`, the two gates could disagree within one run: the removal
-happens, the activation line is withheld, and the host ends the cutover
-with no version manager wired into the interactive shell — exactly the
-failure issue #38 exists to fix.
+Makefile's `MISE_REACHABLE` macro is. The point of sharing the
+login-shell fallback is agreement, not extra reach: `MISE_REACHABLE`
+is what lets `make update` remove asdf and direnv, and if this script
+decided reachability any other way the two gates could disagree within
+one run — the removal happens, the activation line is withheld, and
+the host ends the cutover with no version manager wired into the
+interactive shell, exactly the failure issue #38 exists to fix. (The
+fallback itself sees only the inherited `PATH` plus what a bash login
+shell's startup files add; a bash login shell never reads
+`~/.zprofile`, where `bootstrap.sh` writes the Homebrew shellenv line
+on a stock-zsh host that already has one, so a mise brew-installed in
+the same shell session as bootstrap is not
+necessarily covered. That miss is fail-safe on both gates: the
+activation line is withheld here and the removal is held back there.
+The common case works because the invoking shell already has Homebrew
+on `PATH` and `-lc` inherits it. See the `MISE_REACHABLE` comment in
+the Makefile.)
 
 Like the strip below, the script has more than one caller, and for the
 same reason:

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -64,31 +64,6 @@ Temurin JDK (jre builds are named `temurin-jre-*` and are not
 selected), so the old `filter` / `filter_exclude` keys have native
 equivalents.
 
-### The LuaRocks pin
-
-LuaRocks 3.13.0 ships a rockspec with a duplicate `tag` key. Under
-asdf's lua plugin that broke the build, so this repo pinned 3.12.2 via
-`ASDF_LUA_LUAROCKS_VERSION` — the variable name that plugin reads.
-`scripts/versions_setup.sh` still exports
-`ASDF_LUA_LUAROCKS_VERSION=3.12.2`, so every `make versions-*`
-invocation carries it.
-
-**On mise the export is currently inert.** Verified against mise
-2026.8.6 on 2026-08-16: `mise registry` resolves `lua` through
-`vfox:mise-plugins/vfox-lua` first, not the asdf plugin, and a
-sandboxed `mise install lua@5.4` built 5.4.8 and bootstrapped LuaRocks
-**3.13.0** successfully with the export set. The variable neither took
-effect nor was needed.
-
-It is kept anyway, because it costs nothing and still applies if you
-pin lua to the asdf backend explicitly
-(`lua = "asdf:mise-plugins/mise-lua@5.4"`), where the original breakage
-is unchanged: upstream `luarocks/luarocks#1851` was closed by a fix to
-the *release tooling* (`luarocks/luarocks#1885`), and the shipped
-3.13.0 tarball is PGP-signed with a pinned `source_digest` and was
-never re-rolled. Tracked in
-[issue #6](https://github.com/TheVoskamps/macos-setup/issues/6).
-
 ## `.env` loading
 
 The global config sets:

--- a/scripts/ensure_mise_zshrc_lines.sh
+++ b/scripts/ensure_mise_zshrc_lines.sh
@@ -35,14 +35,21 @@
 #
 # That reachability decision must agree with the Makefile's MISE_REACHABLE
 # probe, which is what let `update` remove asdf and direnv in the first place.
-# MISE_REACHABLE runs under `/bin/bash -lc` precisely because a mise installed
-# moments earlier in the same run lands on a LOGIN shell's PATH, not
-# necessarily on make's. A plain `command -v` here would see only make's
-# non-login PATH, so the two gates could disagree within one run: the probe
-# passes, the old version manager goes, and the activation line is withheld —
-# exactly the fresh-install scenario issue #38 exists to fix. So the gate below
+# The point of sharing MISE_REACHABLE's `/bin/bash -lc` fallback is agreement,
+# not extra reach: if this script decided reachability any other way the two
+# gates could disagree within one run — the removal happens, the activation
+# line is withheld, and the host ends the cutover with no version manager
+# wired into the interactive shell, exactly the fresh-install scenario issue
+# #38 exists to fix. The fallback itself sees only the inherited PATH plus
+# what a bash login shell's startup files add; a bash login shell never reads
+# ~/.zprofile, where bootstrap.sh writes the Homebrew shellenv line on a
+# stock-zsh host that already has one, so a mise brew-installed in the same
+# shell session as bootstrap is not necessarily covered. That miss is
+# fail-safe on both gates: the activation line is withheld here and the
+# removal is held back there. The common case works because the invoking
+# shell already has Homebrew on PATH and `-lc` inherits it. So the gate below
 # checks this shell's PATH first and falls back to the same login-shell probe
-# the Makefile uses.
+# the Makefile uses. See the MISE_REACHABLE comment in the Makefile.
 #
 # ZSHRC_PATH is overridable so the test suite can point it at a fixture, and
 # MISE is overridable (the same knob scripts/mise_common.sh reads) so a test

--- a/scripts/test/ensure_mise_zshrc_lines_test.sh
+++ b/scripts/test/ensure_mise_zshrc_lines_test.sh
@@ -102,12 +102,13 @@ check "case 6: exits zero" "$RC" "0"
 check "case 6: activation line added" "$(grep -cFx "$ACTIVATE_LINE" "$Z6")" "1"
 
 # === case 7: the gate matches the Makefile's MISE_REACHABLE probe ========
-# `update` decides to remove asdf and direnv with MISE_REACHABLE, which runs
-# under a LOGIN shell because a mise installed moments earlier in the same run
-# lands on a login shell's PATH, not necessarily on make's. If this script
-# checked only make's PATH the two gates could disagree within one run — the
-# removal happens, the activation line is withheld. So the script must fall
-# back to the same login-shell probe.
+# `update` decides to remove asdf and direnv with MISE_REACHABLE, whose
+# `/bin/bash -lc` probe sees the inherited PATH plus what a bash login
+# shell's startup files add (never ~/.zprofile — that miss is fail-safe on
+# both gates). What matters here is agreement: if this script decided
+# reachability any other way the two gates could disagree within one run —
+# the removal happens, the activation line is withheld. So the script must
+# fall back to the same login-shell probe.
 if grep -qE '/bin/bash -lc .*command -v' "$SUT"; then
   ok "case 7: the gate falls back to a login-shell probe"
 else

--- a/scripts/test/remove_runner_brew_override_test.sh
+++ b/scripts/test/remove_runner_brew_override_test.sh
@@ -92,10 +92,13 @@ ok_absent() {
 
 # Print every line of <file> that invokes <cmd> in COMMAND position.
 #
-# Comments are stripped first (the header talks about brew and mas
-# constantly), then double-quoted spans (log messages quote the command
+# Double-quoted spans are stripped first (log messages quote the command
 # lines they are about to run, and the `=~` patterns quote their
-# delimiters). What survives is code, and a <cmd> token there that sits at
+# delimiters), then comments (the header talks about brew and mas
+# constantly). Quotes must go first: a `#` inside a quoted string — say a
+# log line citing `issue #123` — would otherwise read as a comment start
+# and truncate the rest of the line, hiding a bare call after it. What
+# survives is code, and a <cmd> token there that sits at
 # the start of a simple command — after start-of-line, whitespace, `;`,
 # `&`, `|`, `(`, or a leading `!` — and is followed by a subcommand or a
 # flag, is a bare invocation.
@@ -111,7 +114,7 @@ ok_absent() {
 # `"$SUDO" mas uninstall` leaves a bare `mas`.
 bare_cmd_hits() {
   # bare_cmd_hits <file> <cmd>
-  sed -E 's/#.*//; s/"[^"]*"//g' "$1" \
+  sed -E 's/"[^"]*"//g; s/#.*//' "$1" \
     | grep -nE "(^|[[:space:]]|[;&|(])(!([[:space:]]+))?$2[[:space:]]+[a-z-]"
 }
 
@@ -148,6 +151,21 @@ static_test() {
     's/"\$MAS" list/mas list/' 'mas list'
   assert_no_bare_cmd sudo \
     's/"\$SUDO" "\$MAS" uninstall/sudo "$MAS" uninstall/' 'sudo "$MAS" uninstall'
+
+  # Pin the strip order inside bare_cmd_hits: a `#` inside a
+  # double-quoted string must not read as a comment start. With comments
+  # stripped before quotes, this appended line's `"commit #123: note"`
+  # would swallow the bare `brew list` after it and the detector would
+  # miss a real reintroduction.
+  local dir appended
+  dir="$(mktemp -d)"
+  appended="$dir/appended_runner.sh"
+  cp "$RUNNER" "$appended"
+  printf '%s\n' 'echo "commit #123: note" && brew list --formula "sentinel"' \
+    >> "$appended"
+  ok "$([[ -n "$(bare_cmd_hits "$appended" brew)" ]] && echo 0 || echo 1)" \
+    "the detector fires on a bare brew call after a #-bearing quoted string"
+  rm -rf "$dir"
 
   ok "$(grep -q '^BREW="\${BREW:-brew}"$' "$RUNNER" && echo 0 || echo 1)" \
     "remove_runner.sh defines the BREW override the way install_filter.sh does"

--- a/scripts/versions_setup.sh
+++ b/scripts/versions_setup.sh
@@ -20,25 +20,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=mise_common.sh
 . "$SCRIPT_DIR/mise_common.sh"
 
-# LuaRocks pin for lua builds. LuaRocks 3.13.0 ships a rockspec with a
-# duplicate 'tag' key; under asdf's lua plugin that broke the build, so this
-# repo pinned 3.12.2. ASDF_LUA_LUAROCKS_VERSION is the variable name that
-# plugin reads.
-#
-# On mise it is currently INERT, and deliberately kept anyway. Verified
-# against mise 2026.8.6 on 2026-08-16: `mise registry` resolves lua through
-# `vfox:mise-plugins/vfox-lua` FIRST, not the asdf plugin, and a sandboxed
-# `mise install lua@5.4` built 5.4.8 and bootstrapped LuaRocks *3.13.0*
-# successfully with this export set. So the variable neither took effect nor
-# needed to. It stays because it costs nothing and still applies to anyone
-# who pins lua to the asdf backend explicitly (`asdf:mise-plugins/mise-lua`),
-# where the original breakage is unchanged: upstream luarocks/luarocks#1851
-# was closed by a fix to the *release tooling* (luarocks/luarocks#1885), and
-# the shipped 3.13.0 tarball is PGP-signed with a pinned source_digest and
-# was never re-rolled. Tracked in:
-# https://github.com/TheVoskamps/macos-setup/issues/6
-export ASDF_LUA_LUAROCKS_VERSION="${ASDF_LUA_LUAROCKS_VERSION:-3.12.2}"
-
 require_mise || exit 1
 
 MODE="${1:-full}"


### PR DESCRIPTION
## Summary

Two accuracy fixes to the mise-cutover machinery and its documentation.

### Misstated mechanisms (#36)

- The `MISE_REACHABLE` comment in the Makefile claimed a bash login
  shell covers a mise installed moments earlier in the same run. It
  does not: `bootstrap.sh` writes the Homebrew shellenv line to
  `~/.zprofile` on a stock-zsh host that already has one, and a bash
  login shell never reads `~/.zprofile`. The comment now states what
  actually holds — inherited PATH plus bash login startup files, the
  same-session bootstrap case is not covered, and the miss is
  fail-safe (the cutover is held back). The probe itself is unchanged.
- `bare_cmd_hits` in
  `scripts/test/remove_runner_brew_override_test.sh` stripped
  comments before double-quoted spans, so a `#` inside a quoted
  string truncated the line and could hide a bare `brew`/`mas`/
  `sudo` call after it. The two sed expressions are swapped (quotes
  first), the explanatory comment is updated, and a new self-check
  appends `echo "commit #123: note" && brew list --formula
  "sentinel"` to a copy of the runner and requires a detector hit,
  pinning the order.

### Inert LuaRocks pin removed (#48)

The `ASDF_LUA_LUAROCKS_VERSION=3.12.2` export was only read by
asdf's lua plugin; under mise, lua resolves through the vfox backend
and the export is provably inert. Removed the export and its comment
block from `scripts/versions_setup.sh`, the "The LuaRocks pin"
section from `docs/VERSION_MANAGEMENT.md`, the matching `CLAUDE.md`
paragraph, and the now-dangling mention in `README.md`'s pointer to
that doc.

## Testing

- Full `scripts/test/` bash suite passes (all files), plus both zsh
  tests (`cr_test.zsh`, `save_load_claude_auth_test.zsh`).
- The new detector self-check fires under the fixed strip order and
  was verified to miss under the old order.
- `npx markdownlint-cli2 CLAUDE.md docs/VERSION_MANAGEMENT.md
  README.md`: 0 issues.

Closes #36
Closes #48