### PR TITLE
Normalize tap spellings in verify.sh's tap check

### DIFF
--- a/profiles/atlassian/Brewfile
+++ b/profiles/atlassian/Brewfile
@@ -1,7 +1,7 @@
 # Brewfile for the 'atlassian' profile
 
 # Taps
-tap 'atlassian/homebrew-acli'
+tap 'atlassian/acli'
 
 # Homebrew formulae
 brew 'acli'

--- a/scripts/test/verify_tap_check_test.sh
+++ b/scripts/test/verify_tap_check_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Tests for verify.sh's tap check (_check_tap, issue #47).
+#
+# Homebrew accepts both `user/name` and `user/homebrew-name` as the same
+# tap on input, but `brew tap` LISTS only the short form. A literal
+# whole-line comparison of the Brewfile's spelling against that listing
+# therefore reports every long-form declaration as missing, making
+# `make verify` exit non-zero on a correctly provisioned host. The fix
+# normalizes the Brewfile spelling to the short form before comparing.
+#
+# These tests stand up a synthetic repo tree in a tmpdir, stub `brew` on
+# PATH so `brew tap` answers with the short form (never touching real
+# Homebrew), point the host tier at a temp dir via MACOS_SETUP_HOST_DIR,
+# and run the repo's verify.sh against a one-line Brewfile. They assert:
+#   - a long-form tap declaration is reported present (exit 0)
+#   - a short-form tap declaration is reported present (exit 0)
+#   - a genuinely untapped tap is still reported missing (exit 1)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+pass=0
+fail=0
+ok_rc() {
+  # ok_rc <actual_rc> <want_rc> <label>
+  if [[ "$1" == "$2" ]]; then echo "PASS: $3"; ((pass++)); else echo "FAIL: $3 (rc=$1 want $2)"; ((fail++)); fi
+}
+ok_contains() {
+  # ok_contains <haystack> <needle> <label>
+  if grep -qF -- "$2" <<<"$1"; then echo "PASS: $3"; ((pass++)); else echo "FAIL: $3 -- output missing [$2]"; ((fail++)); fi
+}
+
+ROOT="$(mktemp -d)"
+HOSTDIR="$(mktemp -d)"
+BINDIR="$(mktemp -d)"
+export MACOS_SETUP_HOST_DIR="$HOSTDIR"
+trap 'rm -rf "$ROOT" "$HOSTDIR" "$BINDIR"' EXIT
+
+mkdir -p "$ROOT/scripts" "$ROOT/default"
+cp "$REPO_ROOT/scripts/config_common.sh" \
+   "$REPO_ROOT/scripts/verify.sh" "$ROOT/scripts/"
+printf 'get_hostname() { echo "vtaptesthost"; }\n' >> "$ROOT/scripts/config_common.sh"
+
+# A stub `brew` whose `tap` subcommand lists the one installed tap under
+# its short name, as real Homebrew does. The Brewfiles below carry only
+# tap lines, so no other subcommand is exercised.
+cat > "$BINDIR/brew" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  tap) printf 'atlassian/acli\n' ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$BINDIR/brew"
+
+run_verify() {
+  # run_verify <tap-line> -> stdout+stderr; rc in global RC
+  echo "$1" > "$ROOT/default/Brewfile"
+  RC=0
+  OUT="$(cd "$ROOT" && PATH="$BINDIR:$PATH" bash scripts/verify.sh 2>&1)" || RC=$?
+}
+
+run_verify "tap 'atlassian/homebrew-acli'"
+ok_contains "$OUT" "tap:atlassian/homebrew-acli (present)" "long-form spelling reported present"
+ok_rc "$RC" 0 "long-form spelling exits 0"
+
+run_verify "tap 'atlassian/acli'"
+ok_contains "$OUT" "tap:atlassian/acli (present)" "short-form spelling reported present"
+ok_rc "$RC" 0 "short-form spelling exits 0"
+
+run_verify "tap 'other/thing'"
+ok_contains "$OUT" "tap:other/thing (missing)" "untapped tap reported missing"
+ok_rc "$RC" 1 "untapped tap exits 1"
+
+echo
+echo "pass=$pass fail=$fail"
+[[ $fail -eq 0 ]] || exit 1
+exit 0

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -143,7 +143,11 @@ _check_brew_cli() {
 
 _check_tap() {
   local tap="$1"
-  if brew tap | grep -qx "$tap"; then
+  # Homebrew accepts both user/name and user/homebrew-name as the same
+  # tap on input, but `brew tap` lists only the short form — compare in
+  # that form so a long-form Brewfile spelling is not reported missing.
+  local short="${tap/\/homebrew-//}"
+  if brew tap | grep -qx "$short"; then
     print_line "tap" "$tap" "present" ""
     return 0
   fi


### PR DESCRIPTION
## Summary

`make verify` reported the `atlassian` tap as missing on a host where it is installed, so a genuinely clean run exited non-zero. Homebrew accepts both `user/name` and `user/homebrew-name` as the same tap on input, but `brew tap` lists only the short form; `_check_tap` compared the Brewfile's literal spelling against that listing with an exact whole-line match, so any long-form declaration could never match.

- **Class fix**: `_check_tap` in `scripts/verify.sh` now strips the `homebrew-` prefix from the repo half before comparing, so both equivalent spellings verify as present.
- **Instance fix**: `profiles/atlassian/Brewfile` moves its one long-form declaration to the short form `atlassian/acli`.
- **Pinned by test**: `scripts/test/verify_tap_check_test.sh` runs verify.sh against a stubbed `brew` that lists the short form (as real Homebrew does) and asserts long form → present/exit 0, short form → present/exit 0, and an untapped tap → still missing/exit 1.

## Verification

- New test: 6/6 pass; `install_filter_trust_tap_test.sh` (14/14, its long-form fixture still agrees with the checker) and `config_profiles_test.sh` (71/71) unaffected.
- Real `make verify` on the previously-failing host: `installed: 107, missing: 0`, exit 0.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UC6N2h95eAg2M6CB2mU6DS