### PR TITLE
Add format-readers, linters and schema-validators profiles

### DIFF
--- a/profiles/format-readers/Brewfile
+++ b/profiles/format-readers/Brewfile
@@ -1,0 +1,15 @@
+# Brewfile for the 'format-readers' profile — query and convert structured
+# data files (JSON, YAML, TOML, XML, CSV) from the shell.
+#
+# Linting and schema validation live in the sibling 'linters' and
+# 'schema-validators' profiles, so a host can take the readers without the
+# checkers.
+
+# Homebrew formulae
+# dasel, jq and yq are installed in the core tier (scripts/config_common.sh
+# queries config.toml with dasel), but format-readers re-asserts them as the
+# profile that owns the reader role. Install is additive and idempotent, so
+# the re-assertion is a no-op on machines that already have them.
+brew 'dasel'        # JSON, YAML, TOML, XML, CSV — one selector syntax
+brew 'jq'           # JSON
+brew 'yq'           # mikefarah's Go yq: YAML, JSON, XML, CSV, properties

--- a/profiles/linters/Brewfile
+++ b/profiles/linters/Brewfile
@@ -1,0 +1,10 @@
+# Brewfile for the 'linters' profile — per-format linters and formatters.
+
+# Homebrew formulae
+brew 'shellcheck'          # shell script
+brew 'markdownlint-cli2'   # Markdown
+brew 'yamllint'            # YAML
+brew 'jsonlint'            # JSON (validator)
+brew 'biome'               # JSON/JSONC lint+format
+brew 'tombi'               # TOML
+brew 'cfn-lint'            # CloudFormation correctness

--- a/profiles/schema-validators/Brewfile
+++ b/profiles/schema-validators/Brewfile
@@ -1,0 +1,9 @@
+# Brewfile for the 'schema-validators' profile — validate documents against
+# a schema or a policy, rather than against a format's grammar (that is the
+# sibling 'linters' profile).
+
+# Homebrew formulae
+brew 'checkov'                # IaC security
+brew 'check-jsonschema'       # JSON/YAML schema validation
+brew 'kube-linter'            # k8s YAML / Helm
+brew 'cloudformation-guard'   # CloudFormation policy-as-code


### PR DESCRIPTION
Three fine-grained profiles split the "read, lint, validate a structured data file" role along the axis of what each tool actually does, so a host can take the readers without the checkers.

| Profile | Formulae | Role |
| --- | --- | --- |
| `format-readers` | `dasel`, `jq`, `yq` | Query and convert JSON/YAML/TOML/XML/CSV |
| `linters` | `shellcheck`, `markdownlint-cli2`, `yamllint`, `jsonlint`, `biome`, `tombi`, `cfn-lint` | Check a document against its format's grammar and style |
| `schema-validators` | `checkov`, `check-jsonschema`, `kube-linter`, `cloudformation-guard` | Check a document against a schema or a policy |

`format-readers` re-asserts three formulae the core tier already installs (`config_common.sh` queries `config.toml` with `dasel`). That is the same additive, idempotent re-assertion `dev-core` makes for `git`: it names the tier that owns the reader role without changing what gets installed on a host that already has them.

Each profile is Brewfile-only — no `post_install`, no `uninstall`/`purge` — so none of them carries a `config.toml`, matching `databases` and `web`.

`brew info --formula` resolves every one of the formulae above from homebrew-core, so no profile needs a `tap` line and none is affected by the Homebrew 6.0 tap-trust requirement.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdFwgaPggHVLWk7GxwQRAx